### PR TITLE
call actions only on successful parse

### DIFF
--- a/src/hammer.c
+++ b/src/hammer.c
@@ -426,6 +426,7 @@ static void test_action(void) {
   
   g_check_parse_ok(action_, "ab", 2, "(u0x41 u0x42)");
   g_check_parse_ok(action_, "AB", 2, "(u0x41 u0x42)");
+  g_check_parse_failed(action_, "XX", 2);
 }
 
 static void test_not_in(void) {

--- a/src/parsers/action.c
+++ b/src/parsers/action.c
@@ -10,8 +10,11 @@ static HParseResult* parse_action(void *env, HParseState *state) {
   if (a->p && a->action) {
     HParseResult *tmp = h_do_parse(a->p, state);
     //HParsedToken *tok = a->action(h_do_parse(a->p, state));
-    const HParsedToken *tok = a->action(tmp);
-    return make_result(state, (HParsedToken*)tok);
+    if(tmp) {
+        const HParsedToken *tok = a->action(tmp);
+        return make_result(state, (HParsedToken*)tok);
+    } else
+      return NULL;
   } else // either the parser's missing or the action's missing
     return NULL;
 }


### PR DESCRIPTION
Pull if this is the way it's supposed to work; cf. issue #17.
