### PR TITLE
allow h_whitespace(p) to succeed on end of input if p succeeds

### DIFF
--- a/src/parsers/whitespace.c
+++ b/src/parsers/whitespace.c
@@ -8,7 +8,7 @@ static HParseResult* parse_whitespace(void* env, HParseState *state) {
     bak = state->input_stream;
     c = h_read_bits(&state->input_stream, 8, false);
     if (state->input_stream.overrun)
-      return NULL;
+      break;
   } while (isspace(c));
   state->input_stream = bak;
   return h_do_parse((HParser*)env, state);

--- a/src/t_parser.c
+++ b/src/t_parser.c
@@ -110,12 +110,17 @@ static void test_float32(void) {
 
 static void test_whitespace(void) {
   const HParser *whitespace_ = h_whitespace(h_ch('a'));
+  const HParser *whitespace_end = h_whitespace(h_end_p());
 
   g_check_parse_ok(whitespace_, "a", 1, "u0x61");
   g_check_parse_ok(whitespace_, " a", 2, "u0x61");
   g_check_parse_ok(whitespace_, "  a", 3, "u0x61");
   g_check_parse_ok(whitespace_, "\ta", 2, "u0x61");
   g_check_parse_failed(whitespace_, "_a", 2);
+
+  g_check_parse_ok(whitespace_end, "", 0, "NULL");
+  g_check_parse_ok(whitespace_end, "  ", 2, "NULL");
+  g_check_parse_failed(whitespace_end, "  x", 3);
 }
 
 static void test_left(void) {


### PR DESCRIPTION
Stumbled across this:

I suppose `h_whitespace(h_end_p())` should succeed if the input consists of only whitespace?
