### PR TITLE
pass rr by reference to set_rdata

### DIFF
--- a/examples/dns.c
+++ b/examples/dns.c
@@ -49,40 +49,40 @@ bool validate_message(HParseResult *p) {
 ///
 
 // Helper: Parse and pack the RDATA field of a Resource Record.
-void set_rdata(struct dns_rr rr, HCountedArray *rdata) {
+void set_rdata(struct dns_rr *rr, HCountedArray *rdata) {
   uint8_t *data = h_arena_malloc(rdata->arena, sizeof(uint8_t)*rdata->used);
   for (size_t i=0; i<rdata->used; ++i)
     data[i] = H_CAST_UINT(rdata->elements[i]);
 
   // Parse RDATA if possible.
   const HParseResult *p = NULL;
-  const HParser *parser = init_rdata(rr.type);
+  const HParser *parser = init_rdata(rr->type);
   if (parser)
     p = h_parse(parser, (const uint8_t*)data, rdata->used);
 
   // If the RR doesn't parse, set its type to 0.
   if (!p) 
-    rr.type = 0;
+    rr->type = 0;
 
   // Pack the parsed rdata into rr.
-  switch(rr.type) {
-  case 1:  rr.a     = H_CAST_UINT(p->ast);             break;
-  case 2:  rr.ns    = *H_CAST(dns_domain_t,   p->ast); break;
-  case 3:  rr.md    = *H_CAST(dns_domain_t,   p->ast); break;
-  case 4:  rr.md    = *H_CAST(dns_domain_t,   p->ast); break;
-  case 5:  rr.cname = *H_CAST(dns_domain_t,   p->ast); break;
-  case 6:  rr.soa   = *H_CAST(dns_rr_soa_t,   p->ast); break;
-  case 7:  rr.mb    = *H_CAST(dns_domain_t,   p->ast); break;
-  case 8:  rr.mg    = *H_CAST(dns_domain_t,   p->ast); break;
-  case 9:  rr.mr    = *H_CAST(dns_domain_t,   p->ast); break;
-  case 10: rr.null  = *H_CAST(dns_rr_null_t,  p->ast); break;
-  case 11: rr.wks   = *H_CAST(dns_rr_wks_t,   p->ast); break;
-  case 12: rr.ptr   = *H_CAST(dns_domain_t,   p->ast); break;
-  case 13: rr.hinfo = *H_CAST(dns_rr_hinfo_t, p->ast); break;
-  case 14: rr.minfo = *H_CAST(dns_rr_minfo_t, p->ast); break;
-  case 15: rr.mx    = *H_CAST(dns_rr_mx_t,    p->ast); break;
-  case 16: rr.txt   = *H_CAST(dns_rr_txt_t,   p->ast); break;
-  default:                                             break;
+  switch(rr->type) {
+  case 1:  rr->a     = H_CAST_UINT(p->ast);             break;
+  case 2:  rr->ns    = *H_CAST(dns_domain_t,   p->ast); break;
+  case 3:  rr->md    = *H_CAST(dns_domain_t,   p->ast); break;
+  case 4:  rr->md    = *H_CAST(dns_domain_t,   p->ast); break;
+  case 5:  rr->cname = *H_CAST(dns_domain_t,   p->ast); break;
+  case 6:  rr->soa   = *H_CAST(dns_rr_soa_t,   p->ast); break;
+  case 7:  rr->mb    = *H_CAST(dns_domain_t,   p->ast); break;
+  case 8:  rr->mg    = *H_CAST(dns_domain_t,   p->ast); break;
+  case 9:  rr->mr    = *H_CAST(dns_domain_t,   p->ast); break;
+  case 10: rr->null  = *H_CAST(dns_rr_null_t,  p->ast); break;
+  case 11: rr->wks   = *H_CAST(dns_rr_wks_t,   p->ast); break;
+  case 12: rr->ptr   = *H_CAST(dns_domain_t,   p->ast); break;
+  case 13: rr->hinfo = *H_CAST(dns_rr_hinfo_t, p->ast); break;
+  case 14: rr->minfo = *H_CAST(dns_rr_minfo_t, p->ast); break;
+  case 15: rr->mx    = *H_CAST(dns_rr_mx_t,    p->ast); break;
+  case 16: rr->txt   = *H_CAST(dns_rr_txt_t,   p->ast); break;
+  default:                                              break;
   }
 }
 
@@ -131,7 +131,7 @@ const HParsedToken* act_rr(const HParseResult *p) {
   rr->rdlength = H_FIELD_SEQ(4)->used;
 
   // Parse and pack RDATA.
-  set_rdata(*rr, H_FIELD_SEQ(4));
+  set_rdata(rr, H_FIELD_SEQ(4));
 
   return H_MAKE(dns_rr_t, rr);
 }


### PR DESCRIPTION
In the DNS example, `set_rdata` was erroneously operating on its local copy of the argument only.
