### PR TITLE
Added clang coverage support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -34,8 +34,11 @@ else:
 if GetOption("coverage"):
     env.Append(CFLAGS=["-fprofile-arcs", "-ftest-coverage"],
                CXXFLAGS=["-fprofile-arcs", "-ftest-coverage"],
-               LDFLAGS=["-fprofile-arcs", "-ftest-coverage"],
-               LIBS=['gcov'])
+               LDFLAGS=["-fprofile-arcs", "-ftest-coverage"])
+    if os.getenv("CC") == "clang":
+        env.Append(LIBS=["profile_rt"])
+    else:
+        env.Append(LIBS=['gcov'])
 
 if os.getenv("CC") == "clang":
     env.Replace(CC="clang",


### PR DESCRIPTION
Clang's coverage runtime support library has a different name. This makes the clang Travis-CI build work.
