### PR TITLE
Ditch longs and long longs in favor of stdint.h types, which has cascadi...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ docs/milestone2.dot.pdf
 *.dot.pdf
 Session.vim
 *.gcov
+cscope.out
+build/
+.sconsign.dblite

--- a/examples/base64.c
+++ b/examples/base64.c
@@ -8,6 +8,7 @@
 // base64_sem1.c and base64_sem2.c for examples how to attach appropriate
 // semantic actions to the grammar.
 
+#include <inttypes.h>
 #include "../src/hammer.h"
 
 const HParser* document = NULL;
@@ -49,12 +50,12 @@ int main(int argc, char **argv)
     init_parser();
 
     inputsize = fread(input, 1, sizeof(input), stdin);
-    fprintf(stderr, "inputsize=%lu\ninput=", inputsize);
+    fprintf(stderr, "inputsize=%zu\ninput=", inputsize);
     fwrite(input, 1, inputsize, stderr);
     result = h_parse(document, input, inputsize);
 
     if(result) {
-        fprintf(stderr, "parsed=%lld bytes\n", result->bit_length/8);
+        fprintf(stderr, "parsed=%" PRId64 " bytes\n", result->bit_length/8);
         h_pprint(stdout, result->ast, 0, 0);
         return 0;
     } else {

--- a/examples/base64_sem1.c
+++ b/examples/base64_sem1.c
@@ -15,6 +15,7 @@
 #include "../src/hammer.h"
 #include "../src/glue.h"
 #include <assert.h>
+#include <inttypes.h>
 
 
 ///
@@ -158,12 +159,12 @@ int main(int argc, char **argv)
     parser = init_parser();
 
     inputsize = fread(input, 1, sizeof(input), stdin);
-    fprintf(stderr, "inputsize=%lu\ninput=", inputsize);
+    fprintf(stderr, "inputsize=%zu\ninput=", inputsize);
     fwrite(input, 1, inputsize, stderr);
     result = h_parse(parser, input, inputsize);
 
     if(result) {
-        fprintf(stderr, "parsed=%lld bytes\n", result->bit_length/8);
+        fprintf(stderr, "parsed=%" PRId64 " bytes\n", result->bit_length/8);
         h_pprint(stdout, result->ast, 0, 0);
         return 0;
     } else {

--- a/examples/base64_sem2.c
+++ b/examples/base64_sem2.c
@@ -16,6 +16,7 @@
 #include "../src/hammer.h"
 #include "../src/glue.h"
 #include <assert.h>
+#include <inttypes.h>
 
 
 ///
@@ -162,12 +163,12 @@ int main(int argc, char **argv)
     parser = init_parser();
 
     inputsize = fread(input, 1, sizeof(input), stdin);
-    fprintf(stderr, "inputsize=%lu\ninput=", inputsize);
+    fprintf(stderr, "inputsize=%zu\ninput=", inputsize);
     fwrite(input, 1, inputsize, stderr);
     result = h_parse(parser, input, inputsize);
 
     if(result) {
-        fprintf(stderr, "parsed=%lld bytes\n", result->bit_length/8);
+        fprintf(stderr, "parsed=%" PRId64 " bytes\n", result->bit_length/8);
         h_pprint(stdout, result->ast, 0, 0);
         return 0;
     } else {

--- a/src/backends/lr.c
+++ b/src/backends/lr.c
@@ -436,14 +436,14 @@ static void pprint_transition(FILE *f, const HCFGrammar *g, const HLRTransition 
 {
   fputs("-", f);
   h_pprint_symbol(f, g, t->symbol);
-  fprintf(f, "->%lu", t->to);
+  fprintf(f, "->%zu", t->to);
 }
 
 void h_pprint_lrdfa(FILE *f, const HCFGrammar *g,
                     const HLRDFA *dfa, unsigned int indent)
 {
   for(size_t i=0; i<dfa->nstates; i++) {
-    unsigned int indent2 = indent + fprintf(f, "%4lu: ", i);
+    unsigned int indent2 = indent + fprintf(f, "%4zu: ", i);
     h_pprint_lrstate(f, g, dfa->states[i], indent2);
     for(HSlistNode *x = dfa->transitions->head; x; x = x->next) {
       const HLRTransition *t = x->elem;
@@ -463,7 +463,7 @@ void pprint_lraction(FILE *f, const HCFGrammar *g, const HLRAction *action)
     if(action->nextstate == HLR_SUCCESS)
       fputs("s~", f);
     else
-      fprintf(f, "s%lu", action->nextstate);
+      fprintf(f, "s%zu", action->nextstate);
     break;
   case HLR_REDUCE:
     fputs("r(", f);
@@ -471,7 +471,7 @@ void pprint_lraction(FILE *f, const HCFGrammar *g, const HLRAction *action)
     fputs(" -> ", f);
 #ifdef NDEBUG
     // if we can't print the production, at least print its length
-    fprintf(f, "[%lu]", action->production.length);
+    fprintf(f, "[%zu]", action->production.length);
 #else
     HCFSequence seq = {action->production.rhs};
     h_pprint_sequence(f, g, &seq);
@@ -510,7 +510,7 @@ void h_pprint_lrtable(FILE *f, const HCFGrammar *g, const HLRTable *table,
 {
   for(size_t i=0; i<table->nrows; i++) {
     for(unsigned int j=0; j<indent; j++) fputc(' ', f);
-    fprintf(f, "%4lu:", i);
+    fprintf(f, "%4zu:", i);
     if(table->forall[i]) {
       fputc(' ', f);
       pprint_lraction(f, g, table->forall[i]);
@@ -531,7 +531,7 @@ void h_pprint_lrtable(FILE *f, const HCFGrammar *g, const HLRTable *table,
 #if 0
   fputs("inadeq=", f);
   for(HSlistNode *x=table->inadeq->head; x; x=x->next) {
-    fprintf(f, "%lu ", (uintptr_t)x->elem);
+    fprintf(f, "%zu ", (uintptr_t)x->elem);
   }
   fputc('\n', f);
 #endif

--- a/src/benchmark.c
+++ b/src/benchmark.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include <stdio.h>
 #include <time.h>
 #include <string.h>
@@ -108,7 +109,7 @@ HBenchmarkResults *h_benchmark__m(HAllocator* mm__, HParser* parser, HParserTest
       // TODO: replace this with a posix timer-based benchmark. (cf. timerfd_create, timer_create, setitimer)
       int count = 1, cur;
       struct timespec ts_start, ts_end;
-      long long time_diff;
+      int64_t time_diff;
       do {
 	count *= 2; // Yes, this means that the first run will run the function twice. This is fine, as we want multiple runs anyway.
   h_benchmark_clock_gettime(&ts_start);
@@ -129,11 +130,11 @@ HBenchmarkResults *h_benchmark__m(HAllocator* mm__, HParser* parser, HParserTest
 
 void h_benchmark_report(FILE* stream, HBenchmarkResults* result) {
   for (size_t i=0; i<result->len; ++i) {
-    fprintf(stream, "Backend %ld ... \n", i);
+    fprintf(stream, "Backend %zd ... \n", i);
     for (size_t j=0; j<result->results[i].n_testcases; ++j) {
       if(result->results[i].cases == NULL)
         continue;
-      fprintf(stream, "Case %ld: %ld ns/parse\n", j,  result->results[i].cases[j].parse_time);
+      fprintf(stream, "Case %zd: %zd ns/parse\n", j,  result->results[i].cases[j].parse_time);
     }
   }
 }

--- a/src/bitreader.c
+++ b/src/bitreader.c
@@ -26,12 +26,12 @@
 #define LDB(range,i) (((i)>>LSB(range))&((1<<(MSB(range)-LSB(range)+1))-1))
 
 
-long long h_read_bits(HInputStream* state, int count, char signed_p) {
+int64_t h_read_bits(HInputStream* state, int count, char signed_p) {
   // BUG: Does not 
-  long long out = 0;
+  int64_t out = 0;
   int offset = 0;
   int final_shift = 0;
-  long long msb = ((signed_p ? 1LL:0) << (count - 1)); // 0 if unsigned, else 1 << (nbits - 1)
+  int64_t msb = ((signed_p ? 1LL:0) << (count - 1)); // 0 if unsigned, else 1 << (nbits - 1)
   
   
   // overflow check...

--- a/src/bitwriter.c
+++ b/src/bitwriter.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include <string.h>
 #include <assert.h>
 #include "hammer.h"
@@ -43,7 +44,7 @@ static void h_bit_writer_reserve(HBitWriter* w, size_t nbits) {
 }
 
 
-void h_bit_writer_put(HBitWriter* w, unsigned long long data, size_t nbits) {
+void h_bit_writer_put(HBitWriter* w, uint64_t data, size_t nbits) {
   assert(nbits > 0); // Less than or equal to zero makes complete nonsense
 
   // expand size...

--- a/src/hammer.h
+++ b/src/hammer.h
@@ -91,7 +91,7 @@ typedef struct HParsedToken_ {
  */
 typedef struct HParseResult_ {
   const HParsedToken *ast;
-  long long bit_length;
+  int64_t bit_length;
   HArena * arena;
 } HParseResult;
 
@@ -589,7 +589,7 @@ HBitWriter *h_bit_writer_new(HAllocator* mm__);
 /**
  * TODO: Document me
  */
-void h_bit_writer_put(HBitWriter* w, unsigned long long data, size_t nbits);
+void h_bit_writer_put(HBitWriter* w, uint64_t data, size_t nbits);
 
 /**
  * TODO: Document me

--- a/src/internal.h
+++ b/src/internal.h
@@ -17,6 +17,7 @@
 
 #ifndef HAMMER_INTERNAL__H
 #define HAMMER_INTERNAL__H
+#include <stdint.h>
 #include <assert.h>
 #include <err.h>
 #include <string.h>
@@ -285,7 +286,7 @@ extern HParserBackendVTable h__glr_backend_vtable;
 
 // TODO(thequux): Set symbol visibility for these functions so that they aren't exported.
 
-long long h_read_bits(HInputStream* state, int count, char signed_p);
+int64_t h_read_bits(HInputStream* state, int count, char signed_p);
 // need to decide if we want to make this public. 
 HParseResult* h_do_parse(const HParser* parser, HParseState *state);
 void put_cached(HParseState *ps, const HParser *p, HParseResult *cached);

--- a/src/parsers/ch.c
+++ b/src/parsers/ch.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include <assert.h>
 #include "parser_internal.h"
 

--- a/src/t_bitreader.c
+++ b/src/t_bitreader.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include <glib.h>
 #include "hammer.h"
 #include "internal.h"
@@ -15,44 +16,44 @@
 
 static void test_bitreader_ints(void) {
   HInputStream is = MK_INPUT_STREAM("\xFF\xFF\xFF\xFE\x00\x00\x00\x00", 8, BIT_BIG_ENDIAN | BYTE_BIG_ENDIAN);
-  g_check_cmplong(h_read_bits(&is, 64, true), ==, -0x200000000);
+  g_check_cmp_int64(h_read_bits(&is, 64, true), ==, -0x200000000);
 }
 
 static void test_bitreader_be(void) {
   HInputStream is = MK_INPUT_STREAM("\x6A\x5A", 2, BIT_BIG_ENDIAN | BYTE_BIG_ENDIAN);
-  g_check_cmpint(h_read_bits(&is, 3, false), ==, 0x03);
-  g_check_cmpint(h_read_bits(&is, 8, false), ==, 0x52);
-  g_check_cmpint(h_read_bits(&is, 5, false), ==, 0x1A);
+  g_check_cmp_int32(h_read_bits(&is, 3, false), ==, 0x03);
+  g_check_cmp_int32(h_read_bits(&is, 8, false), ==, 0x52);
+  g_check_cmp_int32(h_read_bits(&is, 5, false), ==, 0x1A);
 }
 static void test_bitreader_le(void) {
   HInputStream is = MK_INPUT_STREAM("\x6A\x5A", 2, BIT_LITTLE_ENDIAN | BYTE_LITTLE_ENDIAN);
-  g_check_cmpint(h_read_bits(&is, 3, false), ==, 0x02);
-  g_check_cmpint(h_read_bits(&is, 8, false), ==, 0x4D);
-  g_check_cmpint(h_read_bits(&is, 5, false), ==, 0x0B);
+  g_check_cmp_int32(h_read_bits(&is, 3, false), ==, 0x02);
+  g_check_cmp_int32(h_read_bits(&is, 8, false), ==, 0x4D);
+  g_check_cmp_int32(h_read_bits(&is, 5, false), ==, 0x0B);
 }
 
 static void test_largebits_be(void) {
   HInputStream is = MK_INPUT_STREAM("\x6A\x5A", 2, BIT_BIG_ENDIAN | BYTE_BIG_ENDIAN);
-  g_check_cmpint(h_read_bits(&is, 11, false), ==, 0x352);
-  g_check_cmpint(h_read_bits(&is, 5, false), ==, 0x1A);
+  g_check_cmp_int32(h_read_bits(&is, 11, false), ==, 0x352);
+  g_check_cmp_int32(h_read_bits(&is, 5, false), ==, 0x1A);
 }
   
 static void test_largebits_le(void) {
   HInputStream is = MK_INPUT_STREAM("\x6A\x5A", 2, BIT_LITTLE_ENDIAN | BYTE_LITTLE_ENDIAN);
-  g_check_cmpint(h_read_bits(&is, 11, false), ==, 0x26A);
-  g_check_cmpint(h_read_bits(&is, 5, false), ==, 0x0B);
+  g_check_cmp_int32(h_read_bits(&is, 11, false), ==, 0x26A);
+  g_check_cmp_int32(h_read_bits(&is, 5, false), ==, 0x0B);
 }
 
 static void test_offset_largebits_be(void) {
   HInputStream is = MK_INPUT_STREAM("\x6A\x5A", 2, BIT_BIG_ENDIAN | BYTE_BIG_ENDIAN);
-  g_check_cmpint(h_read_bits(&is, 5, false), ==, 0xD);
-  g_check_cmpint(h_read_bits(&is, 11, false), ==, 0x25A);
+  g_check_cmp_int32(h_read_bits(&is, 5, false), ==, 0xD);
+  g_check_cmp_int32(h_read_bits(&is, 11, false), ==, 0x25A);
 }
   
 static void test_offset_largebits_le(void) {
   HInputStream is = MK_INPUT_STREAM("\x6A\x5A", 2, BIT_LITTLE_ENDIAN | BYTE_LITTLE_ENDIAN);
-  g_check_cmpint(h_read_bits(&is, 5, false), ==, 0xA);
-  g_check_cmpint(h_read_bits(&is, 11, false), ==, 0x2D3);
+  g_check_cmp_int32(h_read_bits(&is, 5, false), ==, 0xA);
+  g_check_cmp_int32(h_read_bits(&is, 11, false), ==, 0x2D3);
 }
 
 

--- a/src/t_bitwriter.c
+++ b/src/t_bitwriter.c
@@ -1,10 +1,11 @@
 #include <glib.h>
+#include <stdint.h>
 #include "hammer.h"
 #include "internal.h"
 #include "test_suite.h"
 
 typedef struct {
-  unsigned long long data;
+  uint64_t data;
   size_t nbits;
 } bitwriter_test_elem; // should end with {0,0}
 
@@ -29,7 +30,7 @@ void run_bitwriter_test(bitwriter_test_elem data[], char flags) {
   };
 
   for (i = 0; data[i].nbits; i++) {
-    g_check_cmpulonglong ((unsigned long long)h_read_bits(&input, data[i].nbits, FALSE), ==,  data[i].data);
+    g_check_cmp_uint64((uint64_t)h_read_bits(&input, data[i].nbits, FALSE), ==,  data[i].data);
   }
 }
 

--- a/src/t_misc.c
+++ b/src/t_misc.c
@@ -3,12 +3,12 @@
 #include "hammer.h"
 
 static void test_tt_user(void) {
-  g_check_cmpint(TT_USER, >, TT_NONE);
-  g_check_cmpint(TT_USER, >, TT_BYTES);
-  g_check_cmpint(TT_USER, >, TT_SINT);
-  g_check_cmpint(TT_USER, >, TT_UINT);
-  g_check_cmpint(TT_USER, >, TT_SEQUENCE);
-  g_check_cmpint(TT_USER, >, TT_ERR);
+  g_check_cmp_int32(TT_USER, >, TT_NONE);
+  g_check_cmp_int32(TT_USER, >, TT_BYTES);
+  g_check_cmp_int32(TT_USER, >, TT_SINT);
+  g_check_cmp_int32(TT_USER, >, TT_UINT);
+  g_check_cmp_int32(TT_USER, >, TT_SEQUENCE);
+  g_check_cmp_int32(TT_USER, >, TT_ERR);
 }
 
 void register_misc_tests(void) {

--- a/src/test_suite.h
+++ b/src/test_suite.h
@@ -17,7 +17,9 @@
 
 #ifndef HAMMER_TEST_SUITE__H
 #define HAMMER_TEST_SUITE__H
+#include <stdint.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 // Equivalent to g_assert_*, but not using g_assert...
 #define g_check_inttype(fmt, typ, n1, op, n2) do {				\
@@ -159,7 +161,7 @@
     size_t expected = n;						\
     size_t actual = (table)->used;					\
     if(actual != expected) {						\
-      g_test_message("Check failed: table size should have been %lu, but was %lu", \
+      g_test_message("Check failed: table size should have been %zu, but was %zu", \
 		     expected, actual);					\
       g_test_fail();							\
     }									\
@@ -210,12 +212,10 @@
 
 
 
-#define g_check_cmpint(n1, op, n2) g_check_inttype("%d", int, n1, op, n2)
-#define g_check_cmplong(n1, op, n2) g_check_inttype("%ld", long, n1, op, n2)
-#define g_check_cmplonglong(n1, op, n2) g_check_inttype("%lld", long long, n1, op, n2)
-#define g_check_cmpuint(n1, op, n2) g_check_inttype("%u", unsigned int, n1, op, n2)
-#define g_check_cmpulong(n1, op, n2) g_check_inttype("%lu", unsigned long, n1, op, n2)
-#define g_check_cmpulonglong(n1, op, n2) g_check_inttype("%llu", unsigned long long, n1, op, n2)
+#define g_check_cmp_int32(n1, op, n2) g_check_inttype("%d", int32_t, n1, op, n2)
+#define g_check_cmp_int64(n1, op, n2) g_check_inttype("%" PRId64, int64_t, n1, op, n2)
+#define g_check_cmp_uint32(n1, op, n2) g_check_inttype("%u", uint32_t, n1, op, n2)
+#define g_check_cmp_uint64(n1, op, n2) g_check_inttype("%" PRIu64, uint64_t, n1, op, n2)
 #define g_check_cmpfloat(n1, op, n2) g_check_inttype("%g", float, n1, op, n2)
 #define g_check_cmpdouble(n1, op, n2) g_check_inttype("%g", double, n1, op, n2)
 


### PR DESCRIPTION
...ng

effects throughout, including use of inttypes.h/PRI[ud]64 because printf() is
still stuck in a long world, conversion of %lu to %zu for printing values of
type size_t, and changing/renaming the g_check_cmp\* family of functions.
