### PR TITLE
Fixes for packageconfig

### DIFF
--- a/libhammer.pc.in
+++ b/libhammer.pc.in
@@ -6,5 +6,5 @@ libdir=${exec_prefix}/lib
 Name: libhammer
 Description: The Hammer parsing library
 Version: 0.9.0
-Cflags: -I${includedir}/hammer
+Cflags: -I${includedir}
 Libs: -L${libdir} -lhammer


### PR DESCRIPTION
Don't include hammer in the include path and use the variable for prefix rather than defaulting it.
