### PR TITLE
Fix LC_ID_DYLIB for OS X

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -40,7 +40,7 @@ env.ScanReplace('libhammer.pc.in')
 env.MergeFlags("-std=gnu99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-attributes")
 
 if env['PLATFORM'] == 'darwin':
-    env.Append(SHLINKFLAGS = ['-install_name', '$TARGET'])
+    env.Append(SHLINKFLAGS = '-install_name ' + env["libpath"] + '/${TARGET.file}')
 else:
     env.MergeFlags("-lrt")
 


### PR DESCRIPTION
Wrapping the SHLINKFLAGS in an array rather than as a single string
caused the link flags to be passed to clang double quoted. This cuased
clang to interpret the flags as a string rather than as a flag which
caused the -install_name flag to never be passed to the linker.
