### PR TITLE
remove implicit addition of "TT_" prefix to token-type macros, because i...

### DIFF
--- a/src/glue.h
+++ b/src/glue.h
@@ -193,7 +193,7 @@ HParsedToken *h_make_sint(HArena *arena, int64_t val);
 HParsedToken *h_make_uint(HArena *arena, uint64_t val);
 
 // Standard short-hands to make tokens in an action.
-#define H_MAKE(TYP, VAL)  h_make(p->arena, (HTokenType)TT_ ## TYP, VAL)
+#define H_MAKE(TYP, VAL)  h_make(p->arena, (HTokenType) TYP, VAL)
 #define H_MAKE_SEQ()      h_make_seq(p->arena)
 #define H_MAKE_SEQN(N)    h_make_seqn(p->arena, N)
 #define H_MAKE_BYTES(LEN) h_make_bytes(p->arena, LEN)
@@ -206,7 +206,7 @@ HParsedToken *h_make_uint(HArena *arena, uint64_t val);
 #define h_assert_type(T,P)  (assert(P->token_type == (HTokenType)T), P)
 
 // Convenience short-hand forms of h_assert_type.
-#define H_ASSERT(TYP, TOK)   h_assert_type(TT_ ## TYP, TOK)
+#define H_ASSERT(TYP, TOK)   h_assert_type(TYP, TOK)
 #define H_ASSERT_SEQ(TOK)    h_assert_type(TT_SEQUENCE, TOK)
 #define H_ASSERT_BYTES(TOK)  h_assert_type(TT_BYTES, TOK)
 #define H_ASSERT_SINT(TOK)   h_assert_type(TT_SINT, TOK)


### PR DESCRIPTION
...t's confusing to require them in one place but not others.

Just changing these two lines did not break any of the tests that weren't already broken on my (ia32) machine, and there are no other instances of "\WTT_\W" in the source, so I'm hopeful this is sufficient.
