### PR TITLE
Move backend names into src/benchmark.c

### DIFF
--- a/src/benchmark.c
+++ b/src/benchmark.c
@@ -14,6 +14,14 @@
 #include <sys/resource.h>
 #endif
 
+static const char* HParserBackendNames[] = {
+  "Packrat",
+  "Regular",
+  "LL(k)",
+  "LALR",
+  "GLR"
+};
+
 void h_benchmark_clock_gettime(struct timespec *ts) {
   if (ts == NULL)
     return;

--- a/src/hammer.h
+++ b/src/hammer.h
@@ -46,14 +46,6 @@ typedef enum HParserBackend_ {
   PB_MAX = PB_GLR
 } HParserBackend;
 
-static const char* HParserBackendNames[] = { 
-  "Packrat",
-  "Regular",
-  "LL(k)",
-  "LALR",
-  "GLR"
-};
-
 typedef enum HTokenType_ {
   // Before you change the explicit values of these, think of the poor bindings ;_;
   TT_NONE = 1,


### PR DESCRIPTION
It's causing unreferenced-variable warnings, and isn't referenced
anywhere aside from benchmark.c. If client code is likely to reference
it, perhaps move it into another header, so people who include hammer.h
don't have to refer to it to have warning-free code.
