### PR TITLE
Remove vacuous states in base64_sem?.c

### DIFF
--- a/examples/base64_sem1.c
+++ b/examples/base64_sem1.c
@@ -29,9 +29,9 @@ HParsedToken *act_bsfdig(const HParseResult *p, void* user_data)
 
     uint8_t c = H_CAST_UINT(p->ast);
 
-    if(c >= 0x40 && c <= 0x5A) // A-Z
+    if(c >= 0x41 && c <= 0x5A) // A-Z
         res->uint = c - 0x41;
-    else if(c >= 0x60 && c <= 0x7A) // a-z
+    else if(c >= 0x61 && c <= 0x7A) // a-z
         res->uint = c - 0x61 + 26;
     else if(c >= 0x30 && c <= 0x39) // 0-9
         res->uint = c - 0x30 + 52;

--- a/examples/base64_sem2.c
+++ b/examples/base64_sem2.c
@@ -31,9 +31,9 @@ uint8_t bsfdig_value(const HParsedToken *p)
 
     if(p && p->token_type == TT_UINT) {
         uint8_t c = p->uint;
-        if(c >= 0x40 && c <= 0x5A) // A-Z
+        if(c >= 0x41 && c <= 0x5A) // A-Z
             value = c - 0x41;
-        else if(c >= 0x60 && c <= 0x7A) // a-z
+        else if(c >= 0x61 && c <= 0x7A) // a-z
             value = c - 0x61 + 26;
         else if(c >= 0x30 && c <= 0x39) // 0-9
             value = c - 0x30 + 52;


### PR DESCRIPTION
I don't think these actually affect correctness since there's no way for
0x40 or 0x60 to show up in a parse tree anyway, but they're confusing.
