### PR TITLE
Descend properly in h_seq_index_path

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -173,7 +173,7 @@ HParsedToken *h_seq_index_vpath(const HParsedToken *p, size_t i, va_list va)
   int j;
 
   while((j = va_arg(va, int)) >= 0)
-    ret = h_seq_index(p, j);
+    ret = h_seq_index(ret, j);
 
   return ret;
 }

--- a/src/t_misc.c
+++ b/src/t_misc.c
@@ -2,6 +2,8 @@
 #include <string.h>
 #include "test_suite.h"
 #include "hammer.h"
+#include "internal.h"
+#include "glue.h"
 
 static void test_tt_user(void) {
   g_check_cmp_int32(TT_USER, >, TT_NONE);
@@ -29,7 +31,28 @@ static void test_tt_registry(void) {
   g_check_cmp_int32(h_get_token_type_number("com.upstandinghackers.test.unkown_token_type"), ==, 0);
 }
 
+static void test_seq_index_path(void) {
+  HArena *arena = h_new_arena(&system_allocator, 0);
+
+  HParsedToken *seq = h_make_seqn(arena, 1);
+  HParsedToken *seq2 = h_make_seqn(arena, 2);
+  HParsedToken *tok1 = h_make_uint(arena, 41);
+  HParsedToken *tok2 = h_make_uint(arena, 42);
+
+  seq->seq->elements[0] = seq2;
+  seq->seq->used = 1;
+  seq2->seq->elements[0] = tok1;
+  seq2->seq->elements[1] = tok2;
+  seq2->seq->used = 2;
+
+  g_check_cmp_int(h_seq_index_path(seq, 0, -1)->token_type, ==, TT_SEQUENCE);
+  g_check_cmp_int(h_seq_index_path(seq, 0, 0, -1)->token_type, ==, TT_UINT);
+  g_check_cmp_int64(h_seq_index_path(seq, 0, 0, -1)->uint, ==, 41);
+  g_check_cmp_int64(h_seq_index_path(seq, 0, 1, -1)->uint, ==, 42);
+}
+
 void register_misc_tests(void) {
   g_test_add_func("/core/misc/tt_user", test_tt_user);
   g_test_add_func("/core/misc/tt_registry", test_tt_registry);
+  g_test_add_func("/core/misc/seq_index_path", test_seq_index_path);
 }

--- a/src/t_misc.c
+++ b/src/t_misc.c
@@ -2,8 +2,6 @@
 #include <string.h>
 #include "test_suite.h"
 #include "hammer.h"
-#include "internal.h"
-#include "glue.h"
 
 static void test_tt_user(void) {
   g_check_cmp_int32(TT_USER, >, TT_NONE);
@@ -31,28 +29,7 @@ static void test_tt_registry(void) {
   g_check_cmp_int32(h_get_token_type_number("com.upstandinghackers.test.unkown_token_type"), ==, 0);
 }
 
-static void test_seq_index_path(void) {
-  HArena *arena = h_new_arena(&system_allocator, 0);
-
-  HParsedToken *seq = h_make_seqn(arena, 1);
-  HParsedToken *seq2 = h_make_seqn(arena, 2);
-  HParsedToken *tok1 = h_make_uint(arena, 41);
-  HParsedToken *tok2 = h_make_uint(arena, 42);
-
-  seq->seq->elements[0] = seq2;
-  seq->seq->used = 1;
-  seq2->seq->elements[0] = tok1;
-  seq2->seq->elements[1] = tok2;
-  seq2->seq->used = 2;
-
-  g_check_cmp_int(h_seq_index_path(seq, 0, -1)->token_type, ==, TT_SEQUENCE);
-  g_check_cmp_int(h_seq_index_path(seq, 0, 0, -1)->token_type, ==, TT_UINT);
-  g_check_cmp_int64(h_seq_index_path(seq, 0, 0, -1)->uint, ==, 41);
-  g_check_cmp_int64(h_seq_index_path(seq, 0, 1, -1)->uint, ==, 42);
-}
-
 void register_misc_tests(void) {
   g_test_add_func("/core/misc/tt_user", test_tt_user);
   g_test_add_func("/core/misc/tt_registry", test_tt_registry);
-  g_test_add_func("/core/misc/seq_index_path", test_seq_index_path);
 }

--- a/src/t_regression.c
+++ b/src/t_regression.c
@@ -3,6 +3,7 @@
 #include "glue.h"
 #include "hammer.h"
 #include "test_suite.h"
+#include "internal.h"
 
 static void test_bug118(void) {
   // https://github.com/UpstandingHackers/hammer/issues/118
@@ -33,6 +34,27 @@ static void test_bug118(void) {
     h_parse_result_free(p);
 }
 
+static void test_seq_index_path(void) {
+  HArena *arena = h_new_arena(&system_allocator, 0);
+
+  HParsedToken *seq = h_make_seqn(arena, 1);
+  HParsedToken *seq2 = h_make_seqn(arena, 2);
+  HParsedToken *tok1 = h_make_uint(arena, 41);
+  HParsedToken *tok2 = h_make_uint(arena, 42);
+
+  seq->seq->elements[0] = seq2;
+  seq->seq->used = 1;
+  seq2->seq->elements[0] = tok1;
+  seq2->seq->elements[1] = tok2;
+  seq2->seq->used = 2;
+
+  g_check_cmp_int(h_seq_index_path(seq, 0, -1)->token_type, ==, TT_SEQUENCE);
+  g_check_cmp_int(h_seq_index_path(seq, 0, 0, -1)->token_type, ==, TT_UINT);
+  g_check_cmp_int64(h_seq_index_path(seq, 0, 0, -1)->uint, ==, 41);
+  g_check_cmp_int64(h_seq_index_path(seq, 0, 1, -1)->uint, ==, 42);
+}
+
 void register_regression_tests(void) {
   g_test_add_func("/core/regression/bug118", test_bug118);
+  g_test_add_func("/core/regression/seq_index_path", test_seq_index_path);
 }

--- a/src/test_suite.h
+++ b/src/test_suite.h
@@ -212,6 +212,7 @@
 
 
 
+#define g_check_cmp_int(n1, op, n2) g_check_inttype("%d", int, n1, op, n2)
 #define g_check_cmp_int32(n1, op, n2) g_check_inttype("%d", int32_t, n1, op, n2)
 #define g_check_cmp_int64(n1, op, n2) g_check_inttype("%" PRId64, int64_t, n1, op, n2)
 #define g_check_cmp_uint32(n1, op, n2) g_check_inttype("%u", uint32_t, n1, op, n2)


### PR DESCRIPTION
Stumbled across a bug that makes h `h_seq_index_path` (and the `H_INDEX` and `H_FIELD` macros based on it) not work with paths longer than 1. Derp!