### PR TITLE
Print user defined token type while pretty printing

### DIFF
--- a/src/pprint.c
+++ b/src/pprint.c
@@ -67,11 +67,11 @@ void h_pprint(FILE* stream, const HParsedToken* tok, int indent, int delta) {
   }
     break;
   case TT_USER:
-    fprintf(stream, "%*sUSER\n", indent, "");
+    fprintf(stream, "%*sUSER:%s\n", indent, "", h_get_token_type_name(tok->token_type));
     break;
   default:
     if(tok->token_type > TT_USER) {
-      fprintf(stream, "%*sUSER %d\n", indent, "", tok->token_type-TT_USER);
+      fprintf(stream, "%*sUSER:%s %d\n", indent, "", h_get_token_type_name(tok->token_type), tok->token_type-TT_USER);
     } else {
       assert_message(0, "Should not reach here.");
     }


### PR DESCRIPTION
The pretty printing format chosen is USER:`token name`

We use the registry function `h_get_token_type_name` which returns 0
when no name has been defined. This will print (null) as a token name.