### PR TITLE
Platform compilation improvement (windows port)

### DIFF
--- a/src/backends/regex_debug.c
+++ b/src/backends/regex_debug.c
@@ -3,13 +3,16 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#define USE_DLADDR (0)
 
-
+#if USE_DLADDR
 // This is some spectacularly non-portable code... but whee!
 #include <dlfcn.h>
-char* getsym(void* addr) {
+#endif
+
+char* getsym(HSVMActionFunc addr) {
   char* retstr;
-#if 0
+#if USE_DLADDR
   // This will be fixed later.
   Dl_info dli;
   if (dladdr(addr, &dli) != 0 && dli.dli_sname != NULL) {

--- a/src/backends/regex_debug.c
+++ b/src/backends/regex_debug.c
@@ -1,6 +1,5 @@
 // Intended to be included from regex_debug.c
-#define _GNU_SOURCE
-#include <stdio.h>
+#include "../platform.h"
 #include <stdlib.h>
 
 #define USE_DLADDR (0)
@@ -22,7 +21,7 @@ char* getsym(HSVMActionFunc addr) {
       return retstr;
   } else
 #endif
-    if (asprintf(&retstr, "%p", addr) > 0)
+    if (h_platform_asprintf(&retstr, "%p", addr) > 0)
       return retstr;
     else
       return NULL;

--- a/src/benchmark.c
+++ b/src/benchmark.c
@@ -1,19 +1,10 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
 #include <string.h>
 #include "hammer.h"
 #include "internal.h"
-
-#ifdef __MACH__
-#include <mach/clock.h>
-#include <mach/mach.h>
-#endif
-
-#ifdef __NetBSD__
-#include <sys/resource.h>
-#endif
+#include "platform.h"
 
 static const char* HParserBackendNames[] = {
   "Packrat",
@@ -22,38 +13,6 @@ static const char* HParserBackendNames[] = {
   "LALR",
   "GLR"
 };
-
-void h_benchmark_clock_gettime(struct timespec *ts) {
-  if (ts == NULL)
-    return;
-#ifdef __MACH__ // OS X does not have clock_gettime, use clock_get_time
-  /* 
-   * This returns real time, not CPU time. See http://stackoverflow.com/a/6725161
-   * Possible solution: http://stackoverflow.com/a/11659289
-   */
-  clock_serv_t cclock;
-  mach_timespec_t mts;
-  host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
-  clock_get_time(cclock, &mts);
-  mach_port_deallocate(mach_task_self(), cclock);
-  ts->tv_sec = mts.tv_sec;
-  ts->tv_nsec = mts.tv_nsec;
-#elif defined(__NetBSD__)
-  // NetBSD doesn't have CLOCK_THREAD_CPUTIME_ID. We'll use getrusage instead
-  struct rusage rusage;
-  getrusage(RUSAGE_SELF, &rusage);
-  ts->tv_nsec = (rusage.ru_utime.tv_usec + rusage.ru_stime.tv_usec) * 1000;
-  // not going to overflow; can be at most 2e9-2
-  ts->tv_sec = rusage.ru_utime.tv_sec + rusage.ru_utime.tv_sec;
-  if (ts->tv_nsec >= 1000000000) {
-    ts->tv_nsec -=   1000000000; // subtract a second
-    ts->tv_sec += 1; // add it back.
-  }
-  assert (ts->tv_nsec <= 1000000000);
-#else
-  clock_gettime(CLOCK_THREAD_CPUTIME_ID, ts);
-#endif
-}
 
 /*
   Usage:
@@ -76,6 +35,7 @@ HBenchmarkResults *h_benchmark(HParser* parser, HParserTestcase* testcases) {
   return h_benchmark__m(&system_allocator, parser, testcases);
 }
 
+//TODO(uucidl): replace tabs with the right number of spaces
 HBenchmarkResults *h_benchmark__m(HAllocator* mm__, HParser* parser, HParserTestcase* testcases) {
   // For now, just output the results to stderr
   HParserTestcase* tc = testcases;
@@ -135,20 +95,16 @@ HBenchmarkResults *h_benchmark__m(HAllocator* mm__, HParser* parser, HParserTest
 
     for (tc = testcases; tc->input != NULL; tc++) {
       // The goal is to run each testcase for at least 50ms each
-      // TODO: replace this with a posix timer-based benchmark. (cf. timerfd_create, timer_create, setitimer)
       int count = 1, cur;
-      struct timespec ts_start, ts_end;
       int64_t time_diff;
       do {
 	count *= 2; // Yes, this means that the first run will run the function twice. This is fine, as we want multiple runs anyway.
-  h_benchmark_clock_gettime(&ts_start);
+	struct HStopWatch stopwatch;
+	h_platform_stopwatch_reset(&stopwatch);
 	for (cur = 0; cur < count; cur++) {
 	  h_parse_result_free(h_parse(parser, tc->input, tc->length));
 	}
-  h_benchmark_clock_gettime(&ts_end);
-
-	// time_diff is in ns
-	time_diff = (ts_end.tv_sec - ts_start.tv_sec) * 1000000000 + (ts_end.tv_nsec - ts_start.tv_nsec);
+	time_diff = h_platform_stopwatch_ns(&stopwatch);
       } while (time_diff < 100000000);
       ret->results[backend].cases[cur_case].parse_time = (time_diff / count);
       ret->results[backend].cases[cur_case].length = tc->length;

--- a/src/benchmark.c
+++ b/src/benchmark.c
@@ -35,7 +35,6 @@ HBenchmarkResults *h_benchmark(HParser* parser, HParserTestcase* testcases) {
   return h_benchmark__m(&system_allocator, parser, testcases);
 }
 
-//TODO(uucidl): replace tabs with the right number of spaces
 HBenchmarkResults *h_benchmark__m(HAllocator* mm__, HParser* parser, HParserTestcase* testcases) {
   // For now, just output the results to stderr
   HParserTestcase* tc = testcases;
@@ -67,18 +66,18 @@ HBenchmarkResults *h_benchmark__m(HAllocator* mm__, HParser* parser, HParserTest
       HParseResult *res = h_parse(parser, tc->input, tc->length);
       char* res_unamb;
       if (res != NULL) {
-	res_unamb = h_write_result_unamb(res->ast);
+        res_unamb = h_write_result_unamb(res->ast);
       } else
-	res_unamb = NULL;
+        res_unamb = NULL;
       if ((res_unamb == NULL && tc->output_unambiguous != NULL)
-	  || (res_unamb != NULL && strcmp(res_unamb, tc->output_unambiguous) != 0)) {
-	// test case failed...
-	fprintf(stderr, "Parsing with %s failed\n", HParserBackendNames[backend]);
-	// We want to run all testcases, for purposes of generating a
-	// report. (eg, if users are trying to fix a grammar for a
-	// faster backend)
-	tc_failed++;
-	ret->results[backend].failed_testcases++;
+          || (res_unamb != NULL && strcmp(res_unamb, tc->output_unambiguous) != 0)) {
+        // test case failed...
+        fprintf(stderr, "Parsing with %s failed\n", HParserBackendNames[backend]);
+        // We want to run all testcases, for purposes of generating a
+        // report. (eg, if users are trying to fix a grammar for a
+        // faster backend)
+        tc_failed++;
+        ret->results[backend].failed_testcases++;
       }
       h_parse_result_free(res);
       (&system_allocator)->free(&system_allocator, res_unamb);
@@ -98,13 +97,13 @@ HBenchmarkResults *h_benchmark__m(HAllocator* mm__, HParser* parser, HParserTest
       int count = 1, cur;
       int64_t time_diff;
       do {
-	count *= 2; // Yes, this means that the first run will run the function twice. This is fine, as we want multiple runs anyway.
-	struct HStopWatch stopwatch;
-	h_platform_stopwatch_reset(&stopwatch);
-	for (cur = 0; cur < count; cur++) {
-	  h_parse_result_free(h_parse(parser, tc->input, tc->length));
-	}
-	time_diff = h_platform_stopwatch_ns(&stopwatch);
+        count *= 2; // Yes, this means that the first run will run the function twice. This is fine, as we want multiple runs anyway.
+        struct HStopWatch stopwatch;
+        h_platform_stopwatch_reset(&stopwatch);
+        for (cur = 0; cur < count; cur++) {
+          h_parse_result_free(h_parse(parser, tc->input, tc->length));
+        }
+        time_diff = h_platform_stopwatch_ns(&stopwatch);
       } while (time_diff < 100000000);
       ret->results[backend].cases[cur_case].parse_time = (time_diff / count);
       ret->results[backend].cases[cur_case].length = tc->length;

--- a/src/platform.h
+++ b/src/platform.h
@@ -8,11 +8,48 @@
 
 #include "compiler_specifics.h"
 
+#include <stdint.h>
+
 /* Error Reporting */
 
 /* BSD errx function, seen in err.h */
 H_MSVC_DECLSPEC(noreturn) \
 void h_platform_errx(int err, const char* format, ...)	\
   H_GCC_ATTRIBUTE((noreturn, format (printf,2,3)));
+
+/* Time Measurement */
+
+struct HStopWatch; /* forward definition */
+
+/* initialize a stopwatch */
+void h_platform_stopwatch_reset(struct HStopWatch* stopwatch);
+
+/* return difference between last reset point and now */
+int64_t h_platform_stopwatch_ns(struct HStopWatch* stopwatch);
+
+/* Platform dependent definitions for HStopWatch */
+#if defined(_MSC_VER)
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN 1
+#endif
+#include <windows.h>
+#undef WIN32_LEAN_AND_MEAN
+
+struct HStopWatch {
+  LARGE_INTEGER qpf;
+  LARGE_INTEGER start;
+};
+
+#else
+/* Unix like platforms */
+
+#include <time.h>
+
+struct HStopWatch {
+  struct timespec start;
+};
+
+#endif
 
 #endif

--- a/src/platform.h
+++ b/src/platform.h
@@ -8,7 +8,16 @@
 
 #include "compiler_specifics.h"
 
+#include <stdarg.h>
 #include <stdint.h>
+
+/* String Formatting */
+
+/** see GNU C asprintf */
+int h_platform_asprintf(char **strp, const char *fmt, ...);
+
+/** see GNU C vasprintf */
+int h_platform_vasprintf(char **strp, const char *fmt, va_list arg);
 
 /* Error Reporting */
 

--- a/src/platform_bsdlike.c
+++ b/src/platform_bsdlike.c
@@ -3,8 +3,64 @@
 #include <err.h>
 #include <stdarg.h>
 
+#ifdef __MACH__
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
+
+#ifdef __NetBSD__
+#include <sys/resource.h>
+#endif
+
 void h_platform_errx(int err, const char* format, ...) {
   va_list ap;
   va_start(ap, format);
   verrx(err, format, ap);
+}
+
+// TODO: replace this with a posix timer-based benchmark. (cf. timerfd_create, timer_create, setitimer)
+
+static void gettime(struct timespec *ts) {
+  if (ts == NULL)
+    return;
+#ifdef __MACH__ // OS X does not have clock_gettime, use clock_get_time
+  /*
+   * This returns real time, not CPU time. See http://stackoverflow.com/a/6725161
+   * Possible solution: http://stackoverflow.com/a/11659289
+   */
+  clock_serv_t cclock;
+  mach_timespec_t mts;
+  host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+  clock_get_time(cclock, &mts);
+  mach_port_deallocate(mach_task_self(), cclock);
+  ts->tv_sec = mts.tv_sec;
+  ts->tv_nsec = mts.tv_nsec;
+#elif defined(__NetBSD__)
+  // NetBSD doesn't have CLOCK_THREAD_CPUTIME_ID. We'll use getrusage instead
+  struct rusage rusage;
+  getrusage(RUSAGE_SELF, &rusage);
+  ts->tv_nsec = (rusage.ru_utime.tv_usec + rusage.ru_stime.tv_usec) * 1000;
+  // not going to overflow; can be at most 2e9-2
+  ts->tv_sec = rusage.ru_utime.tv_sec + rusage.ru_utime.tv_sec;
+  if (ts->tv_nsec >= 1000000000) {
+    ts->tv_nsec -=   1000000000; // subtract a second
+    ts->tv_sec += 1; // add it back.
+  }
+  assert (ts->tv_nsec <= 1000000000);
+#else
+  clock_gettime(CLOCK_THREAD_CPUTIME_ID, ts);
+#endif
+}
+
+void h_platform_stopwatch_reset(struct HStopWatch* stopwatch) {
+  gettime(&stopwatch->start);
+}
+
+int64_t h_platform_stopwatch_ns(struct HStopWatch* stopwatch) {
+  struct timespec ts_now;
+  gettime(&ts_now);
+
+  // time_diff is in ns
+  return (ts_now.tv_sec - stopwatch->start.tv_sec) * 1000000000
+	  + (ts_now.tv_nsec - stopwatch->start.tv_nsec);
 }

--- a/src/platform_bsdlike.c
+++ b/src/platform_bsdlike.c
@@ -1,4 +1,7 @@
+#define _GNU_SOURCE // to obtain asprintf/vasprintf
 #include "platform.h"
+
+#include <stdio.h>
 
 #include <err.h>
 #include <stdarg.h>
@@ -11,6 +14,20 @@
 #ifdef __NetBSD__
 #include <sys/resource.h>
 #endif
+
+int h_platform_asprintf(char **strp, const char *fmt, ...)
+{
+  va_list ap;
+  va_start(ap, fmt);
+  int res = h_platform_vasprintf(strp, fmt, ap);
+  va_end(ap);
+  return res;
+}
+
+int h_platform_vasprintf(char **strp, const char *fmt, va_list arg)
+{
+  return vasprintf(strp, fmt, arg);
+}
 
 void h_platform_errx(int err, const char* format, ...) {
   va_list ap;
@@ -62,5 +79,5 @@ int64_t h_platform_stopwatch_ns(struct HStopWatch* stopwatch) {
 
   // time_diff is in ns
   return (ts_now.tv_sec - stopwatch->start.tv_sec) * 1000000000
-	  + (ts_now.tv_nsec - stopwatch->start.tv_nsec);
+          + (ts_now.tv_nsec - stopwatch->start.tv_nsec);
 }

--- a/src/platform_win32.c
+++ b/src/platform_win32.c
@@ -8,3 +8,15 @@ void h_platform_errx(int err, const char* format, ...) {
   ExitProcess(err);
 }
 
+void h_platform_stopwatch_reset(struct HStopWatch* stopwatch) {
+  QueryPerformanceFrequency(&stopwatch->qpf);
+  QueryPerformanceCounter(&stopwatch->start);
+}
+
+/* return difference between last reset point and now */
+int64_t h_platform_stopwatch_ns(struct HStopWatch* stopwatch) {
+  LARGE_INTEGER now;
+  QueryPerformanceCounter(&now);
+
+  return 1000000000 * (now.QuadPart - stopwatch->start.QuadPart) / stopwatch->qpf.QuadPart;
+}

--- a/src/platform_win32.c
+++ b/src/platform_win32.c
@@ -1,7 +1,46 @@
 #include "platform.h"
 
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
 #define WIN32_LEAN_AND_MEAN
-#include "windows.h"
+#include <windows.h>
+
+int h_platform_asprintf(char**strp, const char *fmt, ...)
+{
+  va_list ap;
+  va_start(ap, fmt);
+  int res = h_platform_vasprintf(strp, fmt, ap);
+  va_end(ap);
+  return res;
+}
+
+int h_platform_vasprintf(char**strp, const char *fmt, va_list args)
+{
+  va_list ap;
+  va_copy(ap, args);
+  int non_null_char_count = _vscprintf(fmt, ap);
+  va_end(ap);
+
+  if (non_null_char_count < 0) {
+    return -1;
+  }
+
+  size_t buffer_size = 1 + non_null_char_count;
+  char* buffer = malloc(buffer_size);
+
+  va_copy(ap, args);
+  int res = vsnprintf_s(buffer, buffer_size, non_null_char_count, fmt, ap);
+  if (res < 0) {
+    free(buffer);
+  } else {
+    buffer[non_null_char_count] = 0;
+    *strp = buffer;
+  }
+  va_end(ap);
+
+  return res;
+}
 
 void h_platform_errx(int err, const char* format, ...) {
   // FIXME(windows) TODO(uucidl): to be implemented

--- a/src/system_allocator.c
+++ b/src/system_allocator.c
@@ -6,6 +6,7 @@
 // with this byte:
 // #define DEBUG__MEMFILL 0xFF
 
+#if defined(DEBUG__MEMFILL)
 /**
  * Blocks allocated by the system_allocator start with this header.
  * I.e. the user part of the allocation directly follows.
@@ -16,6 +17,9 @@ typedef struct HDebugBlockHeader_
 } HDebugBlockHeader;
 
 #define BLOCK_HEADER_SIZE (sizeof(HDebugBlockHeader))
+#else
+#define BLOCK_HEADER_SIZE (0)
+#endif
 
 /**
  * Compute the total size needed for a given allocation size.
@@ -46,8 +50,8 @@ static void* system_alloc(HAllocator *allocator, size_t size) {
   void *uptr = user_ptr(block);
 #ifdef DEBUG__MEMFILL
   memset(uptr, DEBUG__MEMFILL, size);
-#endif
   ((HDebugBlockHeader*)block)->size = size;
+#endif
   return uptr;
 }
 
@@ -65,8 +69,8 @@ static void* system_realloc(HAllocator *allocator, void* uptr, size_t size) {
   size_t old_size = ((HDebugBlockHeader*)block)->size;
   if (size > old_size)
     memset((char*)uptr+old_size, DEBUG__MEMFILL, size - old_size);
-#endif
   ((HDebugBlockHeader*)block)->size = size;
+#endif
   return uptr;
 }
 

--- a/src/system_allocator.c
+++ b/src/system_allocator.c
@@ -2,41 +2,77 @@
 #include <stdlib.h>
 #include "internal.h"
 
-//#define DEBUG__MEMFILL 0xFF
+// NOTE(uucidl): undefine to automatically fill up newly allocated block
+// with this byte:
+// #define DEBUG__MEMFILL 0xFF
+
+/**
+ * Blocks allocated by the system_allocator start with this header.
+ * I.e. the user part of the allocation directly follows.
+ */
+typedef struct HDebugBlockHeader_
+{
+  size_t size; /** size of the user allocation */
+} HDebugBlockHeader;
+
+#define BLOCK_HEADER_SIZE (sizeof(HDebugBlockHeader))
+
+/**
+ * Compute the total size needed for a given allocation size.
+ */
+static inline size_t block_size(size_t alloc_size) {
+  return BLOCK_HEADER_SIZE + alloc_size;
+}
+
+/**
+ * Obtain the block containing the user pointer `uptr`
+ */
+static inline void* block_for_user_ptr(void *uptr) {
+  return ((char*)uptr) - BLOCK_HEADER_SIZE;
+}
+
+/**
+ * Obtain the user area of the allocation from a given block
+ */
+static inline void* user_ptr(void *block) {
+  return ((char*)block) + BLOCK_HEADER_SIZE;
+}
 
 static void* system_alloc(HAllocator *allocator, size_t size) {
-  
-  void* ptr = malloc(size + sizeof(size_t));
-  if (!ptr) {
+  void *block = malloc(block_size(size));
+  if (!block) {
     return NULL;
   }
+  void *uptr = user_ptr(block);
 #ifdef DEBUG__MEMFILL
-  memset(ptr, DEBUG__MEMFILL, size + sizeof(size_t));
+  memset(uptr, DEBUG__MEMFILL, size);
 #endif
-  *(size_t*)ptr = size;
-  return ptr + sizeof(size_t);
+  ((HDebugBlockHeader*)block)->size = size;
+  return uptr;
 }
 
-static void* system_realloc(HAllocator *allocator, void* ptr, size_t size) {
-  if (!ptr) {
+static void* system_realloc(HAllocator *allocator, void* uptr, size_t size) {
+  if (!uptr) {
     return system_alloc(allocator, size);
   }
-  ptr = realloc(ptr - sizeof(size_t), size + sizeof(size_t));
-  if (!ptr) {
+  void* block = realloc(block_for_user_ptr(uptr), block_size(size));
+  if (!block) {
     return NULL;
   }
-  *(size_t*)ptr = size;
+  uptr = user_ptr(block);
+
 #ifdef DEBUG__MEMFILL
-  size_t old_size = *(size_t*)ptr;
+  size_t old_size = ((HDebugBlockHeader*)block)->size;
   if (size > old_size)
-    memset(ptr+sizeof(size_t)+old_size, DEBUG__MEMFILL, size - old_size);
+    memset((char*)uptr+old_size, DEBUG__MEMFILL, size - old_size);
 #endif
-  return ptr + sizeof(size_t);
+  ((HDebugBlockHeader*)block)->size = size;
+  return uptr;
 }
 
-static void system_free(HAllocator *allocator, void* ptr) {
-  if (ptr) {
-    free(ptr - sizeof(size_t));
+static void system_free(HAllocator *allocator, void* uptr) {
+  if (uptr) {
+    free(block_for_user_ptr(uptr));
   }
 }
 

--- a/tools/windows/hammer_lib_src_list
+++ b/tools/windows/hammer_lib_src_list
@@ -1,5 +1,6 @@
 platform_win32.c 
-allocator.c 
+allocator.c
+benchmark.c
 bitreader.c 
 bitwriter.c 
 cfgrammar.c 

--- a/tools/windows/hammer_lib_src_list
+++ b/tools/windows/hammer_lib_src_list
@@ -7,6 +7,7 @@ cfgrammar.c
 desugar.c 
 glue.c 
 hammer.c 
+pprint.c
 system_allocator.c
 parsers/action.c 
 parsers/and.c 
@@ -34,6 +35,7 @@ parsers/xor.c
 parsers/value.c 
 backends/packrat.c
 backends/llk.c
+backends/regex.c
 backends/glr.c
 backends/lalr.c
 backends/lr.c

--- a/tools/windows/hammer_lib_src_list
+++ b/tools/windows/hammer_lib_src_list
@@ -7,6 +7,7 @@ cfgrammar.c
 desugar.c 
 glue.c 
 hammer.c 
+system_allocator.c
 parsers/action.c 
 parsers/and.c 
 parsers/attr_bool.c 


### PR DESCRIPTION
Here is a pull request which moves timing primitives into the platform layer & makes system_allocator.c compile with MSVC.

## Timing primitive
The implementation is exactly what it was in benchmark.c and got moved to platform_bsdlike.c (TODO included, about using posix timers)

An implementation for win32 is included, using `QueryPerformanceCounter`

Finally I normalized tabs to spaces in benchmark.c

## System Allocator
We also remove some of the void* arithmetics in system_allocator.c, which allow building
with MSVC, and change the system_allocator to store block sizes only when DEBUG__MEMFILL
is enabled.

@thequux you introduced the memfill mechanism, can you have a look at my changes?

## String Formatting

Since asprintf/vasprintf do not exist in the C standard, we provide an implementation for win32 inside platform_win32.c