### PR TITLE
add a missing end-of-input check in the LL(k) backend

### DIFF
--- a/src/backends/llk.c
+++ b/src/backends/llk.c
@@ -349,6 +349,8 @@ HParseResult *h_llk_parse(HAllocator* mm__, const HParser* parser, HInputStream*
         break;
 
       case HCF_CHAR:
+        if(stream->overrun)
+          goto no_parse;
         if(input != x->chr)
           goto no_parse;
         tok->token_type = TT_UINT;


### PR DESCRIPTION
Stumbled upon a bug: The LL(k) backend could, when processing a single-character terminal, mistake the end of input for a zero byte.