### PR TITLE
Some combinators may report the wrong amount of consumed input

### DIFF
--- a/src/parsers/bind.c
+++ b/src/parsers/bind.c
@@ -49,10 +49,12 @@ static HParseResult *parse_bind(void *be_, HParseState *state) {
         return NULL;
     }
 
-    res = h_do_parse(kx, state);
+    HParseResult *res2 = h_do_parse(kx, state);
+    if(res2)
+        res2->bit_length = 0;   // recalculate
 
     h_delete_arena(arena);
-    return res;
+    return res2;
 }
 
 static const HParserVtable bind_vt = {

--- a/src/parsers/ignoreseq.c
+++ b/src/parsers/ignoreseq.c
@@ -24,8 +24,10 @@ static HParseResult* parse_ignoreseq(void* env, HParseState *state) {
     HParseResult *tmp = h_do_parse(seq->parsers[i], state);
     if (!tmp)
       return NULL;
-    else if (i == seq->which)
+    else if (i == seq->which) {
       res = tmp;
+      res->bit_length = 0;  // recalculate
+    }
   }
 
   return res;

--- a/src/t_regression.c
+++ b/src/t_regression.c
@@ -118,9 +118,30 @@ static void test_llk_zero_end(void) {
     g_check_parse_failed(aze, be, "a", 1);
 }
 
+HParser *k_test_wrong_bit_length(HAllocator *mm__, const HParsedToken *tok, void *env)
+{
+    return h_ch__m(mm__, 'b');
+}
+
+static void test_wrong_bit_length(void) {
+    HParseResult *r;
+    HParser *p;
+
+    p = h_right(h_ch('a'), h_ch('b'));
+    r = h_parse(p, (const uint8_t *)"ab", 2);
+    g_check_cmp_int64(r->bit_length, ==, 16);
+    h_parse_result_free(r);
+
+    p = h_bind(h_ch('a'), k_test_wrong_bit_length, NULL);
+    r = h_parse(p, (const uint8_t *)"ab", 2);
+    g_check_cmp_int64(r->bit_length, ==, 16);
+    h_parse_result_free(r);
+}
+
 void register_regression_tests(void) {
   g_test_add_func("/core/regression/bug118", test_bug118);
   g_test_add_func("/core/regression/seq_index_path", test_seq_index_path);
   g_test_add_func("/core/regression/read_bits_48", test_read_bits_48);
   g_test_add_func("/core/regression/llk_zero_end", test_llk_zero_end);
+  g_test_add_func("/core/regression/wrong_bit_length", test_wrong_bit_length);
 }


### PR DESCRIPTION
Commit af73181c changed it so that `perform_lowlevel_parse` only recalculates the result's `bit_length` if it was set to 0. At least the `h_bind` combinator as well as the `h_left`/`h_right` family of combinators relied on the old behavior. There may be others.