### PR TITLE
Iterative (chunked) input processing

### DIFF
--- a/src/backends/lalr.c
+++ b/src/backends/lalr.c
@@ -355,8 +355,6 @@ HParserBackendVTable h__lalr_backend_vtable = {
 // dummy!
 int test_lalr(void)
 {
-  HAllocator *mm__ = &system_allocator;
-
   /* 
      E -> E '-' T
         | T
@@ -371,44 +369,24 @@ int test_lalr(void)
   h_bind_indirect(E, E_);
   HParser *p = E;
 
-  printf("\n==== G R A M M A R ====\n");
-  HCFGrammar *g = h_cfgrammar_(mm__, h_desugar_augmented(mm__, p));
-  if (g == NULL) {
-    fprintf(stderr, "h_cfgrammar failed\n");
+  HCFGrammar *g = h_pprint_lr_info(stdout, p);
+  if(!g)
     return 1;
-  }
-  h_pprint_grammar(stdout, g, 0);
 
-  printf("\n==== D F A ====\n");
-  HLRDFA *dfa = h_lr0_dfa(g);
-  if (dfa) {
-    h_pprint_lrdfa(stdout, g, dfa, 0);
-  } else {
-    fprintf(stderr, "h_lalr_dfa failed\n");
-  }
-
-  printf("\n==== L R ( 0 )  T A B L E ====\n");
-  HLRTable *table0 = h_lr0_table(g, dfa);
-  if (table0) {
-    h_pprint_lrtable(stdout, g, table0, 0);
-  } else {
-    fprintf(stderr, "h_lr0_table failed\n");
-  }
-  h_lrtable_free(table0);
-
-  printf("\n==== L A L R  T A B L E ====\n");
+  fprintf(stdout, "\n==== L A L R  T A B L E ====\n");
   if (h_compile(p, PB_LALR, NULL)) {
-    fprintf(stderr, "does not compile\n");
+    fprintf(stdout, "does not compile\n");
     return 2;
   }
   h_pprint_lrtable(stdout, g, (HLRTable *)p->backend_data, 0);
 
-  printf("\n==== P A R S E  R E S U L T ====\n");
+  fprintf(stdout, "\n==== P A R S E  R E S U L T ====\n");
   HParseResult *res = h_parse(p, (uint8_t *)"n-(n-((n)))-n", 13);
   if (res) {
     h_pprint(stdout, res->ast, 0, 2);
   } else {
-    printf("no parse\n");
+    fprintf(stdout, "no parse\n");
   }
+
   return 0;
 }

--- a/src/backends/lalr.c
+++ b/src/backends/lalr.c
@@ -346,7 +346,10 @@ void h_lalr_free(HParser *parser)
 HParserBackendVTable h__lalr_backend_vtable = {
   .compile = h_lalr_compile,
   .parse = h_lr_parse,
-  .free = h_lalr_free
+  .free = h_lalr_free,
+  .parse_start = h_lr_parse_start,
+  .parse_chunk = h_lr_parse_chunk,
+  .parse_finish = h_lr_parse_finish
 };
 
 

--- a/src/backends/llk.c
+++ b/src/backends/llk.c
@@ -12,6 +12,7 @@ static const size_t DEFAULT_KMAX = 1;
  * maps lookahead strings to productions (HCFSequence).
  */
 typedef struct HLLkTable_ {
+  size_t     kmax;
   HHashTable *rows;
   HCFChoice  *start;    // start symbol
   HArena     *arena;
@@ -188,6 +189,7 @@ static int fill_table_row(size_t kmax, HCFGrammar *g, HStringMap *row,
  */
 static int fill_table(size_t kmax, HCFGrammar *g, HLLkTable *table)
 {
+  table->kmax = kmax;
   table->start = g->start;
 
   // iterate over g->nts

--- a/src/backends/llk.c
+++ b/src/backends/llk.c
@@ -286,7 +286,7 @@ typedef struct {
 // execute on their corresponding result.
 // also on the stack below the mark, we store the previously accumulated
 // value for the surrounding production.
-static void *MARK = (void *)-1; // stack frame delimiter
+static void const * const MARK = &MARK; // stack frame delimiter
 
 static HLLkState *llk_parse_start_(HAllocator* mm__, const HParser* parser)
 {
@@ -421,9 +421,9 @@ static HCountedArray *llk_parse_chunk_(HLLkState *s, const HParser* parser,
       assert(!p->items[0] || p->items[0] != x);
 
       // push stack frame
-      h_slist_push(stack, seq);   // save current partial value
-      h_slist_push(stack, x);     // save the nonterminal
-      h_slist_push(stack, MARK);  // frame delimiter
+      h_slist_push(stack, seq);           // save current partial value
+      h_slist_push(stack, x);             // save the nonterminal
+      h_slist_push(stack, (void *)MARK);  // frame delimiter
 
       // open a fresh result sequence
       seq = h_carray_new(arena);

--- a/src/backends/llk.c
+++ b/src/backends/llk.c
@@ -276,8 +276,7 @@ typedef struct {
 // execute on their corresponding result.
 // also on the stack below the mark, we store the previously accumulated
 // value for the surrounding production.
-static int dummy;
-static void *MARK = &dummy;   // stack frame delimiter
+static void *MARK = (void *)-1; // stack frame delimiter
 
 static HLLkState *llk_parse_start_(HAllocator* mm__, const HParser* parser)
 {
@@ -329,7 +328,7 @@ static HCountedArray *llk_parse_chunk_(HLLkState *s, const HParser* parser,
       const HCFSequence *p = h_llk_lookup(table, x, stream);
       if(p == NULL)
         goto no_parse;
-      if(p == H_NEED_INPUT)
+      if(p == NEED_INPUT)
         goto need_input;
 
       // an infinite loop case that shouldn't happen

--- a/src/backends/lr.c
+++ b/src/backends/lr.c
@@ -351,7 +351,9 @@ HParseResult *h_lrengine_result(HLREngine *engine)
     // on top of the stack is the start symbol's semantic value
     assert(!h_slist_empty(engine->stack));
     HParsedToken *tok = engine->stack->head->elem;
-    return make_result(engine->arena, tok);
+    HParseResult *res =  make_result(engine->arena, tok);
+    res->bit_length = engine->input.index * 8;
+    return res;
   } else {
     return NULL;
   }

--- a/src/backends/lr.c
+++ b/src/backends/lr.c
@@ -538,3 +538,35 @@ void h_pprint_lrtable(FILE *f, const HCFGrammar *g, const HLRTable *table,
   fputc('\n', f);
 #endif
 }
+
+HCFGrammar *h_pprint_lr_info(FILE *f, HParser *p)
+{
+  HAllocator *mm__ = &system_allocator;
+
+  fprintf(f, "\n==== G R A M M A R ====\n");
+  HCFGrammar *g = h_cfgrammar_(mm__, h_desugar_augmented(mm__, p));
+  if (g == NULL) {
+    fprintf(f, "h_cfgrammar failed\n");
+    return NULL;
+  }
+  h_pprint_grammar(f, g, 0);
+
+  fprintf(f, "\n==== D F A ====\n");
+  HLRDFA *dfa = h_lr0_dfa(g);
+  if (dfa) {
+    h_pprint_lrdfa(f, g, dfa, 0);
+  } else {
+    fprintf(f, "h_lalr_dfa failed\n");
+  }
+
+  fprintf(f, "\n==== L R ( 0 )  T A B L E ====\n");
+  HLRTable *table0 = h_lr0_table(g, dfa);
+  if (table0) {
+    h_pprint_lrtable(f, g, table0, 0);
+  } else {
+    fprintf(f, "h_lr0_table failed\n");
+  }
+  h_lrtable_free(table0);
+
+  return g;
+}

--- a/src/backends/lr.h
+++ b/src/backends/lr.h
@@ -143,5 +143,6 @@ void h_pprint_lrdfa(FILE *f, const HCFGrammar *g,
                     const HLRDFA *dfa, unsigned int indent);
 void h_pprint_lrtable(FILE *f, const HCFGrammar *g, const HLRTable *table,
                       unsigned int indent);
+HCFGrammar *h_pprint_lr_info(FILE *f, HParser *p);
 
 #endif

--- a/src/backends/lr.h
+++ b/src/backends/lr.h
@@ -134,6 +134,9 @@ const HLRAction *h_lrengine_action(const HLREngine *engine);
 bool h_lrengine_step(HLREngine *engine, const HLRAction *action);
 HParseResult *h_lrengine_result(HLREngine *engine);
 HParseResult *h_lr_parse(HAllocator* mm__, const HParser* parser, HInputStream* stream);
+void h_lr_parse_start(HSuspendedParser *s);
+bool h_lr_parse_chunk(HSuspendedParser* s, HInputStream *stream);
+HParseResult *h_lr_parse_finish(HSuspendedParser *s);
 HParseResult *h_glr_parse(HAllocator* mm__, const HParser* parser, HInputStream* stream);
 
 void h_pprint_lritem(FILE *f, const HCFGrammar *g, const HLRItem *item);

--- a/src/cfgrammar.c
+++ b/src/cfgrammar.c
@@ -349,7 +349,7 @@ void *h_stringmap_get(const HStringMap *m, const uint8_t *str, size_t n, bool en
   return m->epsilon_branch;
 }
 
-// A NULL result means no parse. H_NEED_INPUT means lookahead is too short.
+// A NULL result means no parse. NEED_INPUT means lookahead is too short.
 void *h_stringmap_get_lookahead(const HStringMap *m, HInputStream lookahead)
 {
   while(m) {
@@ -368,7 +368,7 @@ void *h_stringmap_get_lookahead(const HStringMap *m, HInputStream lookahead)
         // XXX assumption of byte-wise grammar and input
         return m->end_branch;
       } else {
-        return H_NEED_INPUT;
+        return NEED_INPUT;
       }
     }
 

--- a/src/cfgrammar.c
+++ b/src/cfgrammar.c
@@ -349,6 +349,7 @@ void *h_stringmap_get(const HStringMap *m, const uint8_t *str, size_t n, bool en
   return m->epsilon_branch;
 }
 
+// A NULL result means no parse. H_NEED_INPUT means lookahead is too short.
 void *h_stringmap_get_lookahead(const HStringMap *m, HInputStream lookahead)
 {
   while(m) {
@@ -362,9 +363,13 @@ void *h_stringmap_get_lookahead(const HStringMap *m, HInputStream lookahead)
     // reading bits from it does not consume them from the real input.
     uint8_t c = h_read_bits(&lookahead, 8, false);
     
-    if (lookahead.overrun) {     // end of input
-      // XXX assumption of byte-wise grammar and input
-      return m->end_branch;
+    if (lookahead.overrun) {        // end of chunk
+      if (lookahead.last_chunk) {   // end of input
+        // XXX assumption of byte-wise grammar and input
+        return m->end_branch;
+      } else {
+        return H_NEED_INPUT;
+      }
     }
 
     // no match yet, descend

--- a/src/cfgrammar.h
+++ b/src/cfgrammar.h
@@ -56,6 +56,9 @@ bool h_stringmap_empty(const HStringMap *m);
 static inline HStringMap *h_stringmap_get_char(const HStringMap *m, const uint8_t c)
  { return h_hashtable_get(m->char_branches, (void *)char_key(c)); }
 
+// dummy return value used by h_stringmap_get_lookahead when out of input
+#define H_NEED_INPUT ((void *)&h_stringmap_get_lookahead)
+
 
 /* Convert 'parser' into CFG representation by desugaring and compiling the set
  * of nonterminals.

--- a/src/cfgrammar.h
+++ b/src/cfgrammar.h
@@ -57,7 +57,7 @@ static inline HStringMap *h_stringmap_get_char(const HStringMap *m, const uint8_
  { return h_hashtable_get(m->char_branches, (void *)char_key(c)); }
 
 // dummy return value used by h_stringmap_get_lookahead when out of input
-#define H_NEED_INPUT ((void *)&h_stringmap_get_lookahead)
+#define NEED_INPUT ((void *)-1)
 
 
 /* Convert 'parser' into CFG representation by desugaring and compiling the set

--- a/src/hammer.c
+++ b/src/hammer.c
@@ -56,7 +56,8 @@ HParseResult* h_parse__m(HAllocator* mm__, const HParser* parser, const uint8_t*
     .overrun = 0,
     .endianness = DEFAULT_ENDIANNESS,
     .length = length,
-    .input = input
+    .input = input,
+    .last_chunk = true
   };
   
   return backends[parser->backend]->parse(mm__, parser, &input_stream);
@@ -132,7 +133,8 @@ bool h_parse_chunk(HSuspendedParser* s, const uint8_t* input, size_t length) {
     .overrun = 0,
     .endianness = s->endianness,
     .length = length,
-    .input = input
+    .input = input,
+    .last_chunk = false
   };
 
   // process chunk

--- a/src/hammer.h
+++ b/src/hammer.h
@@ -140,6 +140,8 @@ typedef struct HParser_ {
   HCFChoice *desugared; /* if the parser can be desugared, its desugared form */
 } HParser;
 
+typedef struct HSuspendedParser_ HSuspendedParser;
+
 /**
  * Type of an action to apply to an AST, used in the action() parser. 
  * It can be any (user-defined) function that takes a HParseResult*
@@ -264,6 +266,27 @@ typedef struct HBenchmarkResults_ {
  * piece of input (of known size).
  */
 HAMMER_FN_DECL(HParseResult*, h_parse, const HParser* parser, const uint8_t* input, size_t length);
+
+/**
+ * Initialize a parser for iteratively consuming an input stream in chunks.
+ * This is only supported by some backends.
+ *
+ * Result is NULL if not supported by the backend.
+ */
+HAMMER_FN_DECL(HSuspendedParser*, h_parse_start, const HParser* parser);
+
+/**
+ * Run a suspended parser (as returned by h_parse_start) on a chunk of input.
+ *
+ * Returns true if the parser is done (needs no more input).
+ */
+bool h_parse_chunk(HSuspendedParser* s, const uint8_t* input, size_t length);
+
+/**
+ * Finish an iterative parse. Signals the end of input to the backend and
+ * returns the parse result.
+ */
+HParseResult* h_parse_finish(HSuspendedParser* s);
 
 /**
  * Given a string, returns a parser that parses that string value. 

--- a/src/internal.h
+++ b/src/internal.h
@@ -79,6 +79,7 @@ typedef struct HInputStream_ {
 	       // towards that should be ignored.
   char endianness;
   bool overrun;
+  bool last_chunk;
 } HInputStream;
 
 typedef struct HSlistNode_ {

--- a/src/internal.h
+++ b/src/internal.h
@@ -225,13 +225,13 @@ typedef struct HParserBackendVTable_ {
   void (*free)(HParser* parser);
 
   void (*parse_start)(HSuspendedParser *s);
-    // parse_start should allocate backend_state.
+    // parse_start should allocate s->backend_state.
   void (*parse_chunk)(HSuspendedParser *s, HInputStream *input);
     // when parse_chunk leaves input.overrun unset, parse is done. else:
-    // parse_chunk MUST consume all input, integrating it into backend_state.
+    // parse_chunk MUST consume all input, integrating it into s->backend_state.
     // calling parse_chunk again after parse is done should have no effect.
   HParseResult *(*parse_finish)(HSuspendedParser *s);
-    // parse_finish must free backend_state.
+    // parse_finish must free s->backend_state.
 } HParserBackendVTable;
 
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -78,7 +78,7 @@ typedef struct HInputStream_ {
   char margin; // The number of bits on the end that is being read
 	       // towards that should be ignored.
   char endianness;
-  char overrun;
+  bool overrun;
 } HInputStream;
 
 typedef struct HSlistNode_ {

--- a/src/t_parser.c
+++ b/src/t_parser.c
@@ -743,8 +743,8 @@ void register_parser_tests(void) {
   g_test_add_data_func("/core/parser/regex/uint32", GINT_TO_POINTER(PB_REGULAR), test_uint32);
   g_test_add_data_func("/core/parser/regex/uint16", GINT_TO_POINTER(PB_REGULAR), test_uint16);
   g_test_add_data_func("/core/parser/regex/uint8", GINT_TO_POINTER(PB_REGULAR), test_uint8);
-  g_test_add_data_func("/core/parser/regex/int_range", GINT_TO_POINTER(PB_REGULAR), test_int_range);
 #if 0
+  g_test_add_data_func("/core/parser/regex/int_range", GINT_TO_POINTER(PB_REGULAR), test_int_range);
   g_test_add_data_func("/core/parser/regex/float64", GINT_TO_POINTER(PB_REGULAR), test_float64);
   g_test_add_data_func("/core/parser/regex/float32", GINT_TO_POINTER(PB_REGULAR), test_float32);
 #endif

--- a/src/t_parser.c
+++ b/src/t_parser.c
@@ -462,16 +462,24 @@ static void test_iterative(gconstpointer backend) {
   g_check_parse_chunks_failed(p, be, "foo",3, "baz",3);
 
   p = h_choice(h_token((uint8_t*)"foobar", 6),
-               h_token((uint8_t*)"foopar", 6), NULL);
+               h_token((uint8_t*)"phupar", 6), NULL);
   g_check_parse_chunks_match(p, be, "foo",3, "bar",3, "<66.6f.6f.62.61.72>");
   g_check_parse_chunks_match(p, be, "foo",3, "barbaz",6, "<66.6f.6f.62.61.72>");
-  g_check_parse_chunks_match(p, be, "foo",3, "par",3, "<66.6f.6f.70.61.72>");
+  g_check_parse_chunks_match(p, be, "phu",3, "par",3, "<70.68.75.70.61.72>");
   g_check_parse_chunks_failed(p, be, "fou",3, "bar",3);
   g_check_parse_chunks_failed(p, be, "foo",3, "baz",3);
   g_check_parse_chunks_match(p, be, "foobar",6, "",0, "<66.6f.6f.62.61.72>");
   g_check_parse_chunks_match(p, be, "",0, "foobar",6, "<66.6f.6f.62.61.72>");
   g_check_parse_chunks_failed(p, be, "foo",3, "",0);
   g_check_parse_chunks_failed(p, be, "",0, "foo",3);
+
+  p = h_sequence(h_ch('f'), h_choice(h_token((uint8_t*)"oo", 2),
+                                     h_token((uint8_t*)"uu", 2), NULL), NULL);
+  g_check_parse_chunks_match(p, be, "f",1, "oo",2, "(u0x66 <6f.6f>)");
+  g_check_parse_chunks_match(p, be, "f",1, "uu",2, "(u0x66 <75.75>)");
+  g_check_parse_chunks_failed(p, be, "g",1, "oo",2);
+  g_check_parse_chunks_failed(p, be, "f",1, "ou",2);
+  g_check_parse_chunks_failed(p, be, "f",1, "uo",2);
 }
 
 static void test_ambiguous(gconstpointer backend) {

--- a/src/t_parser.c
+++ b/src/t_parser.c
@@ -883,6 +883,9 @@ void register_parser_tests(void) {
   g_test_add_data_func("/core/parser/lalr/leftrec-ne", GINT_TO_POINTER(PB_LALR), test_leftrec_ne);
   g_test_add_data_func("/core/parser/lalr/rightrec", GINT_TO_POINTER(PB_LALR), test_rightrec);
   g_test_add_data_func("/core/parser/lalr/result_length", GINT_TO_POINTER(PB_LALR), test_result_length);
+  g_test_add_data_func("/core/parser/lalr/iterative", GINT_TO_POINTER(PB_LALR), test_iterative);
+  g_test_add_data_func("/core/parser/lalr/iterative/lookahead", GINT_TO_POINTER(PB_LALR), test_iterative_lookahead);
+  g_test_add_data_func("/core/parser/lalr/iterative/result_length", GINT_TO_POINTER(PB_LALR), test_iterative_result_length);
 
   g_test_add_data_func("/core/parser/glr/token", GINT_TO_POINTER(PB_GLR), test_token);
   g_test_add_data_func("/core/parser/glr/ch", GINT_TO_POINTER(PB_GLR), test_ch);

--- a/src/t_parser.c
+++ b/src/t_parser.c
@@ -503,6 +503,55 @@ static void test_iterative_lookahead(gconstpointer backend) {
   g_check_parse_chunks_failed_(p, "fo",2, "b",1);
 }
 
+static void test_iterative_result_length(gconstpointer backend) {
+  HParserBackend be = (HParserBackend)GPOINTER_TO_INT(backend);
+  HParser *p = h_token((uint8_t*)"foobar", 6);
+
+  if(h_compile(p, be, NULL) != 0) {
+    g_test_message("Compile failed");
+    g_test_fail();
+    return;
+  }
+
+  HSuspendedParser *s = h_parse_start(p);
+  if(!s) {
+    g_test_message("Chunked parsing not available");
+    g_test_fail();
+    return;
+  }
+  h_parse_chunk(s, (uint8_t*)"foo", 3);
+  h_parse_chunk(s, (uint8_t*)"ba", 2);
+  h_parse_chunk(s, (uint8_t*)"rbaz", 4);
+  HParseResult *r = h_parse_finish(s);
+  if(!r) {
+    g_test_message("Parse failed");
+    g_test_fail();
+    return;
+  }
+
+  g_check_cmp_int64(r->bit_length, ==, 48);
+}
+
+static void test_result_length(gconstpointer backend) {
+  HParserBackend be = (HParserBackend)GPOINTER_TO_INT(backend);
+  HParser *p = h_token((uint8_t*)"foo", 3);
+
+  if(h_compile(p, be, NULL) != 0) {
+    g_test_message("Compile failed");
+    g_test_fail();
+    return;
+  }
+
+  HParseResult *r = h_parse(p, (uint8_t*)"foobar", 6);
+  if(!r) {
+    g_test_message("Parse failed");
+    g_test_fail();
+    return;
+  }
+
+  g_check_cmp_int64(r->bit_length, ==, 24);
+}
+
 static void test_ambiguous(gconstpointer backend) {
   HParser *d_ = h_ch('d');
   HParser *p_ = h_ch('+');
@@ -713,6 +762,7 @@ void register_parser_tests(void) {
   g_test_add_data_func("/core/parser/packrat/putget", GINT_TO_POINTER(PB_PACKRAT), test_put_get);
   g_test_add_data_func("/core/parser/packrat/permutation", GINT_TO_POINTER(PB_PACKRAT), test_permutation);
   g_test_add_data_func("/core/parser/packrat/bind", GINT_TO_POINTER(PB_PACKRAT), test_bind);
+  g_test_add_data_func("/core/parser/packrat/result_length", GINT_TO_POINTER(PB_PACKRAT), test_result_length);
 
   g_test_add_data_func("/core/parser/llk/token", GINT_TO_POINTER(PB_LLk), test_token);
   g_test_add_data_func("/core/parser/llk/ch", GINT_TO_POINTER(PB_LLk), test_ch);
@@ -751,8 +801,10 @@ void register_parser_tests(void) {
   g_test_add_data_func("/core/parser/llk/ignore", GINT_TO_POINTER(PB_LLk), test_ignore);
   //g_test_add_data_func("/core/parser/llk/leftrec", GINT_TO_POINTER(PB_LLk), test_leftrec);
   g_test_add_data_func("/core/parser/llk/rightrec", GINT_TO_POINTER(PB_LLk), test_rightrec);
+ g_test_add_data_func("/core/parser/llk/result_length", GINT_TO_POINTER(PB_LLk), test_result_length);
   g_test_add_data_func("/core/parser/llk/iterative", GINT_TO_POINTER(PB_LLk), test_iterative);
   g_test_add_data_func("/core/parser/llk/iterative/lookahead", GINT_TO_POINTER(PB_LLk), test_iterative_lookahead);
+  g_test_add_data_func("/core/parser/llk/iterative/result_length", GINT_TO_POINTER(PB_LLk), test_iterative_result_length);
 
   g_test_add_data_func("/core/parser/regex/token", GINT_TO_POINTER(PB_REGULAR), test_token);
   g_test_add_data_func("/core/parser/regex/ch", GINT_TO_POINTER(PB_REGULAR), test_ch);
@@ -790,6 +842,7 @@ void register_parser_tests(void) {
   g_test_add_data_func("/core/parser/regex/epsilon_p", GINT_TO_POINTER(PB_REGULAR), test_epsilon_p);
   g_test_add_data_func("/core/parser/regex/attr_bool", GINT_TO_POINTER(PB_REGULAR), test_attr_bool);
   g_test_add_data_func("/core/parser/regex/ignore", GINT_TO_POINTER(PB_REGULAR), test_ignore);
+  g_test_add_data_func("/core/parser/regex/result_length", GINT_TO_POINTER(PB_REGULAR), test_result_length);
 
   g_test_add_data_func("/core/parser/lalr/token", GINT_TO_POINTER(PB_LALR), test_token);
   g_test_add_data_func("/core/parser/lalr/ch", GINT_TO_POINTER(PB_LALR), test_ch);
@@ -829,6 +882,7 @@ void register_parser_tests(void) {
   g_test_add_data_func("/core/parser/lalr/leftrec", GINT_TO_POINTER(PB_LALR), test_leftrec);
   g_test_add_data_func("/core/parser/lalr/leftrec-ne", GINT_TO_POINTER(PB_LALR), test_leftrec_ne);
   g_test_add_data_func("/core/parser/lalr/rightrec", GINT_TO_POINTER(PB_LALR), test_rightrec);
+  g_test_add_data_func("/core/parser/lalr/result_length", GINT_TO_POINTER(PB_LALR), test_result_length);
 
   g_test_add_data_func("/core/parser/glr/token", GINT_TO_POINTER(PB_GLR), test_token);
   g_test_add_data_func("/core/parser/glr/ch", GINT_TO_POINTER(PB_GLR), test_ch);
@@ -869,4 +923,5 @@ void register_parser_tests(void) {
   g_test_add_data_func("/core/parser/glr/leftrec-ne", GINT_TO_POINTER(PB_GLR), test_leftrec_ne);
   g_test_add_data_func("/core/parser/glr/rightrec", GINT_TO_POINTER(PB_GLR), test_rightrec);
   g_test_add_data_func("/core/parser/glr/ambiguous", GINT_TO_POINTER(PB_GLR), test_ambiguous);
+  g_test_add_data_func("/core/parser/glr/result_length", GINT_TO_POINTER(PB_GLR), test_result_length);
 }

--- a/src/test_suite.h
+++ b/src/test_suite.h
@@ -90,7 +90,8 @@
 #define g_check_parse_failed(parser, backend, input, inp_len) do {	\
     int skip = h_compile((HParser *)(parser), (HParserBackend)backend, NULL); \
     if(skip != 0) {	\
-      g_test_message("Backend not applicable, skipping test");	\
+      g_test_message("Compile failed");					\
+      g_test_fail();							\
       break;	\
     }	\
     const HParseResult *result = h_parse(parser, (const uint8_t*)input, inp_len); \
@@ -103,7 +104,8 @@
 #define g_check_parse_ok(parser, backend, input, inp_len) do {		\
     int skip = h_compile((HParser *)(parser), (HParserBackend) backend, NULL); \
     if(skip) {								\
-      g_test_message("Backend not applicable, skipping test");		\
+      g_test_message("Compile failed");					\
+      g_test_fail();							\
       break;								\
     }									\
     HParseResult *res = h_parse(parser, (const uint8_t*)input, inp_len); \
@@ -124,7 +126,8 @@
 #define g_check_parse_match(parser, backend, input, inp_len, result) do { \
     int skip = h_compile((HParser *)(parser), (HParserBackend) backend, NULL); \
     if(skip) {								\
-      g_test_message("Backend not applicable, skipping test");		\
+      g_test_message("Compile failed");					\
+      g_test_fail();							\
       break;								\
     }									\
     HParseResult *res = h_parse(parser, (const uint8_t*)input, inp_len); \
@@ -147,9 +150,15 @@
 
 #define g_check_parse_chunks_failed(parser, backend, chunk1, c1_len, chunk2, c2_len) do {	\
     int skip = h_compile((HParser *)(parser), (HParserBackend)backend, NULL); \
+    if(skip) {								\
+      g_test_message("Compile failed");					\
+      g_test_fail();							\
+      break;								\
+    }									\
     HSuspendedParser *s = h_parse_start(parser);			\
-    if(skip || !s) {							\
-      g_test_message("Backend not applicable, skipping test");		\
+    if(!s) {								\
+      g_test_message("Chunk-wise parsing not available");		\
+      g_test_fail();							\
       break;								\
     }									\
     h_parse_chunk(s, (const uint8_t*)chunk1, c1_len);			\
@@ -163,9 +172,15 @@
 
 #define g_check_parse_chunks_match(parser, backend, chunk1, c1_len, chunk2, c2_len, result) do { \
     int skip = h_compile((HParser *)(parser), (HParserBackend) backend, NULL); \
+    if(skip) {								\
+      g_test_message("Compile failed");					\
+      g_test_fail();							\
+      break;								\
+    }									\
     HSuspendedParser *s = h_parse_start(parser);			\
-    if(skip || !s) {							\
-      g_test_message("Backend not applicable, skipping test");		\
+    if(!s) {								\
+      g_test_message("Chunk-wise parsing not available");		\
+      g_test_fail();							\
       break;								\
     }									\
     h_parse_chunk(s, (const uint8_t*)chunk1, c1_len);			\

--- a/src/test_suite.h
+++ b/src/test_suite.h
@@ -155,6 +155,10 @@
       g_test_fail();							\
       break;								\
     }									\
+    g_check_parse_chunks_failed_(parser, chunk1, c1_len, chunk2, c2_len); \
+  } while(0)
+
+#define g_check_parse_chunks_failed_(parser, chunk1, c1_len, chunk2, c2_len) do {	\
     HSuspendedParser *s = h_parse_start(parser);			\
     if(!s) {								\
       g_test_message("Chunk-wise parsing not available");		\
@@ -177,6 +181,10 @@
       g_test_fail();							\
       break;								\
     }									\
+    g_check_parse_chunks_match_(parser, chunk1, c1_len, chunk2, c2_len, result); \
+  } while(0)
+
+#define g_check_parse_chunks_match_(parser, chunk1, c1_len, chunk2, c2_len, result) do { \
     HSuspendedParser *s = h_parse_start(parser);			\
     if(!s) {								\
       g_test_message("Chunk-wise parsing not available");		\


### PR DESCRIPTION
I think I accidentally picked the hardest backend to add this to first, but alas. Adds three new functions to the Hammer API and implements them for the LL(k) backend:
```
HSuspendedParser* h_parse_start(const HParser* parser);  // has __m variant
bool h_parse_chunk(HSuspendedParser* s, const uint8_t* input, size_t length);
HParseResult* h_parse_finish(HSuspendedParser* s);
```

In addition, this branch contains a few tidbits that aren't strictly speaking part of chunking:
* Made it so that tests no longer silently "succeed" when `h_compile` fails. This exposed the `int_range` test on regex not compiling (not implemented). I disabled the test.
* Changed my weird use of a single-byte allocation for a dummy address to just use `((void *)-1)` as an unused pointer value besides NULL. I think that's OK, right?
* Noticed that none of the context-free backends set the parse result's `bit_length`. Added tests and fixed it.