### PR TITLE
Add workaround for VS2015 so that appveyor works

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ build_script:
     } Else {
       $env:VCVARS_PLATFORM="amd64"
     }
+    ren 'C:\Program Files (x86)\Windows Kits\10\include\wdf' '00wdf'
 - call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" %VCVARS_PLATFORM%
 - call tools\windows\build.bat
 # FIXME(windows) TODO(uucidl): reactivate examples


### PR DESCRIPTION
It seems Appveyor's images have been changed. The builds could not
find standard library headers anymore.

It seems to be an interaction between MS' scripts and the Windows
Driver Kit that is installed there.

One way to disable this interaction is to rename the `wdf` folder to
some other name.

See:
- http://stackoverflow.com/questions/31862627/vs2015-cl-cant-find-crt-libs-stido-h-ctype-h-etc-when-building-on-command-l
- http://help.appveyor.com/discussions/problems/3062-problem-with-new-updates-visual-studio-2015-and-cmake
- https://github.com/appveyor/ci/issues/414