### PR TITLE
Remove now unneeded workaround

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,6 @@ build_script:
     } Else {
       $env:VCVARS_PLATFORM="amd64"
     }
-    ren 'C:\Program Files (x86)\Windows Kits\10\include\wdf' '00wdf'
 - call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" %VCVARS_PLATFORM%
 - call tools\windows\build.bat
 # FIXME(windows) TODO(uucidl): reactivate examples


### PR DESCRIPTION
The workaround would now cause build failures in Appveyor as seem to
have pre-emptively applied it to their environments.

I'm not too happy about their handling of the issue. Seems fiddly.

Anyway this commit is now required to build on Appveyor.