### PR TITLE
add platform.h to distribution headers

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -7,7 +7,8 @@ dist_headers = [
     "allocator.h",
     "compiler_specifics.h",
     "glue.h",
-    "internal.h"
+    "internal.h",
+    "platform.h"
 ]
 
 parsers_headers = [


### PR DESCRIPTION
`internal.h` includes `platform.h`, so `platform.h` also needs to ship as an include. Relatedly, we need to clean up our API.