### PR TITLE
Don't create dummy LR-cache entries for parsers that will never recurse

### DIFF
--- a/src/backends/packrat.c
+++ b/src/backends/packrat.c
@@ -186,6 +186,7 @@ HParseResult* h_do_parse(const HParser* parser, HParseState *state) {
   if (!m) {
     // It doesn't exist, so create a dummy result to cache
     HLeftRec *base = a_new(HLeftRec, 1);
+    // But only cache it now if there's some chance it could grow; primitive parsers can't
     if (parser->vtable->higher) {
       base->seed = NULL; base->rule = parser; base->head = NULL;
       h_slist_push(state->lr_stack, base);

--- a/src/internal.h
+++ b/src/internal.h
@@ -278,9 +278,9 @@ typedef struct HRecursionHead_ {
 /* A left recursion.
  *
  * Members:
- *   seed -
- *   rule -
- *   head -
+ *   seed - the HResult yielded by rule
+ *   rule - the HParser that produces seed
+ *   head - the 
  */
 typedef struct HLeftRec_ {
   HParseResult *seed;
@@ -419,6 +419,7 @@ struct HParserVtable_ {
   bool (*isValidCF)(void *env);
   bool (*compile_to_rvm)(HRVMProg *prog, void* env); // FIXME: forgot what the bool return value was supposed to mean.
   void (*desugar)(HAllocator *mm__, HCFStack *stk__, void *env);
+  bool higher; // false if primitive
 };
 
 bool h_false(void*);

--- a/src/parsers/action.c
+++ b/src/parsers/action.c
@@ -81,6 +81,7 @@ static const HParserVtable action_vt = {
   .isValidCF = action_isValidCF,
   .desugar = desugar_action,
   .compile_to_rvm = action_ctrvm,
+  .higher = true,
 };
 
 HParser* h_action(const HParser* p, const HAction a, void* user_data) {

--- a/src/parsers/and.c
+++ b/src/parsers/and.c
@@ -17,6 +17,7 @@ static const HParserVtable and_vt = {
 				revision. --mlp, 18/12/12 */
   .isValidCF = h_false,      /* despite TODO above, this remains false. */
   .compile_to_rvm = h_not_regular,
+  .higher = true,
 };
 
 

--- a/src/parsers/attr_bool.c
+++ b/src/parsers/attr_bool.c
@@ -79,6 +79,7 @@ static const HParserVtable attr_bool_vt = {
   .isValidCF = ab_isValidCF,
   .desugar = desugar_ab,
   .compile_to_rvm = ab_ctrvm,
+  .higher = true,
 };
 
 

--- a/src/parsers/bind.c
+++ b/src/parsers/bind.c
@@ -60,6 +60,7 @@ static const HParserVtable bind_vt = {
     .isValidRegular = h_false,
     .isValidCF = h_false,
     .compile_to_rvm = h_not_regular,
+    .higher = true,
 };
 
 HParser *h_bind(const HParser *p, HContinuation k, void *env)

--- a/src/parsers/bits.c
+++ b/src/parsers/bits.c
@@ -102,6 +102,7 @@ static const HParserVtable bits_vt = {
   .isValidCF = h_true,
   .desugar = desugar_bits,
   .compile_to_rvm = bits_ctrvm,
+  .higher = false,
 };
 
 HParser* h_bits(size_t len, bool sign) {

--- a/src/parsers/butnot.c
+++ b/src/parsers/butnot.c
@@ -40,6 +40,7 @@ static const HParserVtable butnot_vt = {
   .isValidRegular = h_false,
   .isValidCF = h_false, // XXX should this be true if both p1 and p2 are CF?
   .compile_to_rvm = h_not_regular,
+  .higher = true,
 };
 
 HParser* h_butnot(const HParser* p1, const HParser* p2) {

--- a/src/parsers/ch.c
+++ b/src/parsers/ch.c
@@ -47,6 +47,7 @@ static const HParserVtable ch_vt = {
   .isValidCF = h_true,
   .desugar = desugar_ch,
   .compile_to_rvm = ch_ctrvm,
+  .higher = false,
 };
 
 HParser* h_ch(const uint8_t c) {

--- a/src/parsers/charset.c
+++ b/src/parsers/charset.c
@@ -76,6 +76,7 @@ static const HParserVtable charset_vt = {
   .isValidCF = h_true,
   .desugar = desugar_charset,
   .compile_to_rvm = cs_ctrvm,
+  .higher = false,
 };
 
 HParser* h_ch_range(const uint8_t lower, const uint8_t upper) {

--- a/src/parsers/choice.c
+++ b/src/parsers/choice.c
@@ -75,6 +75,7 @@ static const HParserVtable choice_vt = {
   .isValidCF = choice_isValidCF,
   .desugar = desugar_choice,
   .compile_to_rvm = choice_ctrvm,
+  .higher = true,
 };
 
 HParser* h_choice(HParser* p, ...) {

--- a/src/parsers/difference.c
+++ b/src/parsers/difference.c
@@ -39,6 +39,7 @@ static HParserVtable difference_vt = {
   .isValidRegular = h_false,
   .isValidCF = h_false, // XXX should this be true if both p1 and p2 are CF?
   .compile_to_rvm = h_not_regular,
+  .higher = true,
 };
 
 HParser* h_difference(const HParser* p1, const HParser* p2) {

--- a/src/parsers/end.c
+++ b/src/parsers/end.c
@@ -25,6 +25,7 @@ static const HParserVtable end_vt = {
   .isValidCF = h_true,
   .desugar = desugar_end,
   .compile_to_rvm = end_ctrvm,
+  .higher = false,
 };
 
 HParser* h_end_p() {

--- a/src/parsers/endianness.c
+++ b/src/parsers/endianness.c
@@ -46,6 +46,7 @@ static const HParserVtable endianness_vt = {
     .isValidCF = h_false,
     .desugar = NULL,
     .compile_to_rvm = h_not_regular,
+    .higher = true,
 };
 
 HParser* h_with_endianness(char endianness, const HParser *p)

--- a/src/parsers/epsilon.c
+++ b/src/parsers/epsilon.c
@@ -18,6 +18,7 @@ static const HParserVtable epsilon_vt = {
   .isValidCF = h_true,
   .desugar = desugar_epsilon,
   .compile_to_rvm = epsilon_ctrvm,
+  .higher = false,
 };
 
 HParser* h_epsilon_p() {

--- a/src/parsers/ignore.c
+++ b/src/parsers/ignore.c
@@ -49,6 +49,7 @@ static const HParserVtable ignore_vt = {
   .isValidCF = ignore_isValidCF,
   .desugar = desugar_ignore,
   .compile_to_rvm = ignore_ctrvm,
+  .higher = true,
 };
 
 HParser* h_ignore(const HParser* p) {

--- a/src/parsers/ignoreseq.c
+++ b/src/parsers/ignoreseq.c
@@ -103,6 +103,7 @@ static const HParserVtable ignoreseq_vt = {
   .isValidCF = is_isValidCF,
   .desugar = desugar_ignoreseq,
   .compile_to_rvm = is_ctrvm,
+  .higher = true,
 };
 
 

--- a/src/parsers/indirect.c
+++ b/src/parsers/indirect.c
@@ -31,6 +31,7 @@ static const HParserVtable indirect_vt = {
   .isValidCF = indirect_isValidCF,
   .desugar = desugar_indirect,
   .compile_to_rvm = h_not_regular,
+  .higher = true,
 };
 
 void h_bind_indirect__m(HAllocator *mm__, HParser* indirect, const HParser* inner) {

--- a/src/parsers/int_range.c
+++ b/src/parsers/int_range.c
@@ -117,6 +117,7 @@ static const HParserVtable int_range_vt = {
   .isValidCF = h_true,
   .desugar = desugar_int_range,
   .compile_to_rvm = ir_ctrvm,
+  .higher = false,
 };
 
 HParser* h_int_range(const HParser *p, const int64_t lower, const int64_t upper) {

--- a/src/parsers/many.c
+++ b/src/parsers/many.c
@@ -199,6 +199,7 @@ static const HParserVtable many_vt = {
   .isValidCF = many_isValidCF,
   .desugar = desugar_many,
   .compile_to_rvm = many_ctrvm,
+  .higher = true,
 };
 
 HParser* h_many(const HParser* p) {

--- a/src/parsers/not.c
+++ b/src/parsers/not.c
@@ -15,6 +15,7 @@ static const HParserVtable not_vt = {
   .isValidRegular = h_false,  /* see and.c for why */
   .isValidCF = h_false,
   .compile_to_rvm = h_not_regular, // Is actually regular, but the generation step is currently unable to handle it. TODO: fix this.
+  .higher = true,
 };
 
 HParser* h_not(const HParser* p) {

--- a/src/parsers/nothing.c
+++ b/src/parsers/nothing.c
@@ -22,6 +22,7 @@ static const HParserVtable nothing_vt = {
   .isValidCF = h_true,
   .desugar = desugar_nothing,
   .compile_to_rvm = nothing_ctrvm,
+  .higher = false,
 };
 
 HParser* h_nothing_p() {

--- a/src/parsers/optional.c
+++ b/src/parsers/optional.c
@@ -84,6 +84,7 @@ static const HParserVtable optional_vt = {
   .isValidCF = opt_isValidCF,
   .desugar = desugar_optional,
   .compile_to_rvm = opt_ctrvm,
+  .higher = true,
 };
 
 HParser* h_optional(const HParser* p) {

--- a/src/parsers/permutation.c
+++ b/src/parsers/permutation.c
@@ -104,6 +104,7 @@ static const HParserVtable permutation_vt = {
   .isValidCF = h_false,
   .desugar = NULL,
   .compile_to_rvm = h_not_regular,
+  .higher = true,
 };
 
 HParser* h_permutation(HParser* p, ...) {

--- a/src/parsers/sequence.c
+++ b/src/parsers/sequence.c
@@ -93,6 +93,7 @@ static const HParserVtable sequence_vt = {
   .isValidCF = sequence_isValidCF,
   .desugar = desugar_sequence,
   .compile_to_rvm = sequence_ctrvm,
+  .higher = true,
 };
 
 HParser* h_sequence(HParser* p, ...) {

--- a/src/parsers/token.c
+++ b/src/parsers/token.c
@@ -73,6 +73,7 @@ const HParserVtable token_vt = {
   .isValidCF = h_true,
   .desugar = desugar_token,
   .compile_to_rvm = token_ctrvm,
+  .higher = false,
 };
 
 HParser* h_token(const uint8_t *str, const size_t len) {

--- a/src/parsers/unimplemented.c
+++ b/src/parsers/unimplemented.c
@@ -18,6 +18,7 @@ static const HParserVtable unimplemented_vt = {
   .isValidCF = h_false,
   .desugar = NULL,
   .compile_to_rvm = h_not_regular,
+  .higher = true,
 };
 
 static HParser unimplemented = {

--- a/src/parsers/value.c
+++ b/src/parsers/value.c
@@ -26,6 +26,7 @@ static const HParserVtable put_vt = {
   .isValidRegular = h_false,
   .isValidCF = h_false,
   .compile_to_rvm = h_not_regular,
+  .higher = true,
 };
 
 HParser* h_put_value(const HParser* p, const char* name) {
@@ -55,6 +56,7 @@ static const HParserVtable get_vt = {
   .isValidRegular = h_false,
   .isValidCF = h_false,
   .compile_to_rvm = h_not_regular,
+  .higher = true,
 };
 
 HParser* h_get_value(const char* name) {

--- a/src/parsers/whitespace.c
+++ b/src/parsers/whitespace.c
@@ -75,6 +75,7 @@ static const HParserVtable whitespace_vt = {
   .isValidCF = ws_isValidCF,
   .desugar = desugar_whitespace,
   .compile_to_rvm = ws_ctrvm,
+  .higher = false,
 };
 
 HParser* h_whitespace(const HParser* p) {

--- a/src/parsers/xor.c
+++ b/src/parsers/xor.c
@@ -36,6 +36,7 @@ static const HParserVtable xor_vt = {
   .isValidRegular = h_false,
   .isValidCF = h_false, // XXX should this be true if both p1 and p2 are CF?
   .compile_to_rvm = h_not_regular,
+  .higher = true,
 };
 
 HParser* h_xor(const HParser* p1, const HParser* p2) {


### PR DESCRIPTION
The `h_do_parse` function in the packrat backend caches two kinds of values: partial parse results that will continue into another left recursion, aka `HLeftRec`, and full parse results, aka `HParseResult` (the "left" and "right" types of the `HParserCacheValue` union respectively).

Although we're using djbhash, which is pretty cheap, profiling indicates we are spending more time in it than anywhere else, so I'm looking for places to eliminate uses of the hashtable. In the "`recall()` comes up empty" branch of `h_do_parse`, the dummy `HLeftRec` that gets cached is useless when the parser is primitive, so restricting its use to higher-order combinators saves us a put and a get on every application of a primitive parser.

This improved performance on @geal's mp4 benchmark from about 29000ns/iteration to about 22000ns/iteration.