### PR TITLE
Finish porting parsers to windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,12 +92,12 @@ matrix:
       env: BINDINGS=cpp CC=clang
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install lcov
+  - sudo apt-get install -y lcov
   - gem install coveralls-lcov
   - if [ "$BINDINGS" != "none" ]; then sudo apt-get install -qq swig; fi
   - if [ "$BINDINGS" == "perl" ]; then sudo add-apt-repository ppa:dns/irc -y; sudo apt-get update -qq; sudo apt-get install -qq swig=2.0.8-1irc1~12.04; fi
   - if [ "$BINDINGS" == "python" ]; then sudo apt-get install -qq python-dev; fi
-  - if [ "$BINDINGS" == "dotnet" ]; then sudo add-apt-repository ppa:directhex/monoxide -y; sudo apt-get update -qq; sudo apt-get install -qq mono-devel mono-mcs nunit nunit-console; mozroots --import --sync; fi
+  - if [ "$BINDINGS" == "dotnet" ]; then sudo add-apt-repository ppa:directhex/monoxide -y; sudo apt-get update -qq; sudo apt-get install -y -qq mono-devel mono-mcs nunit nunit-console; mozroots --import --sync; fi
 install: true
 before_script:
   - if [ "$BINDINGS" == "php" ]; then phpenv config-add src/bindings/php/hammer.ini; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,5 @@ build_script:
     }
 - call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" %VCVARS_PLATFORM%
 - call tools\windows\build.bat
-# FIXME(windows) TODO(uucidl): reactivate examples
-# - call tools\windows\build_examples.bat
+- call tools\windows\build_examples.bat
 - exit /b 0

--- a/examples/grammar.c
+++ b/examples/grammar.c
@@ -22,11 +22,12 @@
 const char *nonterminal_name(const HCFGrammar *g, const HCFChoice *nt) {
   // if user_data exists and is printable:
   if(nt->user_data != NULL && *(char*)(nt->user_data) > ' ' && *(char*)(nt->user_data) < 127) {
-    if(*(char*)(nt->user_data) != '0') {
+    char* user_str = (char*)(nt->user_data);
+    if(*user_str != '\0') {
       // user_data is a non-empty string
-      return nt->user_data;
+      return user_str;
     } else {
-      return nt->user_data+1;
+      return user_str+1;
     }
   }
   

--- a/src/datastructures.c
+++ b/src/datastructures.c
@@ -52,14 +52,14 @@ HSlist* h_slist_copy(HSlist *slist) {
     h_slist_push(ret, head->elem);
     tail = ret->head;
     head = head->next;
-  }
-  while (head != NULL) {
-    // append head item to tail in a new node
-    HSlistNode *node = h_arena_malloc(slist->arena, sizeof(HSlistNode));
-    node->elem = head->elem;
-    node->next = NULL;
-    tail = tail->next = node;
-    head = head->next;
+    while (head != NULL) {
+      // append head item to tail in a new node
+      HSlistNode *node = h_arena_malloc(slist->arena, sizeof(HSlistNode));
+      node->elem = head->elem;
+      node->next = NULL;
+      tail = tail->next = node;
+      head = head->next;
+    }
   }
   return ret;
 }

--- a/src/parsers/nothing.c
+++ b/src/parsers/nothing.c
@@ -1,6 +1,8 @@
 #include "parser_internal.h"
 
-static HParseResult* parse_nothing() {
+static HParseResult* parse_nothing(void* x,HParseState* y) {
+  (void)(x);
+  (void)(y);
   // not a mistake, this parser always fails
   return NULL;
 }

--- a/src/registry.c
+++ b/src/registry.c
@@ -15,10 +15,16 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-#include <search.h>
 #include <stdlib.h>
 #include "hammer.h"
 #include "internal.h"
+#include "tsearch.h"
+
+#if defined(_MSC_VER)
+#define h_strdup _strdup
+#else
+#define h_strdup strdup
+#endif
 
 typedef struct Entry_ {
   const char* name;
@@ -58,7 +64,7 @@ HTokenType h_allocate_token_type(const char* name) {
     return probe->value;
   } else {
     // new value
-    probe->name = strdup(probe->name); // drop ownership of name
+    probe->name = h_strdup(probe->name); // drop ownership of name
     probe->value = tt_next++;
     if ((probe->value - TT_START) >= tt_by_id_sz) {
       if (tt_by_id_sz == 0) {

--- a/src/search.h
+++ b/src/search.h
@@ -1,0 +1,15 @@
+#if defined(_MSC_VER)
+/* find or insert datum into search tree */
+void *tsearch(const void *vkey, void **vrootp,
+              int (*compar)(const void *, const void *));
+
+/* delete node with given key */
+void * tdelete(const void *vkey, void **vrootp,
+               int (*compar)(const void *, const void *));
+
+/* Walk the nodes of a tree */
+void twalk(const void *vroot, void (*action)(const void *, VISIT, int));
+
+#else
+#include <search.h>
+#endif

--- a/src/tsearch.c
+++ b/src/tsearch.c
@@ -1,0 +1,141 @@
+/*	$OpenBSD: tsearch.c,v 1.9 2015/08/20 21:49:29 deraadt Exp $	*/
+
+/*
+ * Tree search generalized from Knuth (6.2.2) Algorithm T just like
+ * the AT&T man page says.
+ *
+ * The node_t structure is for internal use only
+ *
+ * Written by reading the System V Interface Definition, not the code.
+ *
+ * Totally public domain.
+ */
+
+#include <stdlib.h>
+#include "tsearch.h"
+
+typedef struct node_t {
+    char	  *key;
+    struct node_t *left, *right;
+} node;
+
+/* find or insert datum into search tree */
+void *
+tsearch(const void *vkey, void **vrootp,
+    int (*compar)(const void *, const void *))
+{
+    node *q;
+    char *key = (char *)vkey;
+    node **rootp = (node **)vrootp;
+
+    if (rootp == (struct node_t **)0)
+	return ((void *)0);
+    while (*rootp != (struct node_t *)0) {	/* Knuth's T1: */
+	int r;
+
+	if ((r = (*compar)(key, (*rootp)->key)) == 0)	/* T2: */
+	    return ((void *)*rootp);		/* we found it! */
+	rootp = (r < 0) ?
+	    &(*rootp)->left :		/* T3: follow left branch */
+	    &(*rootp)->right;		/* T4: follow right branch */
+    }
+    q = malloc(sizeof(node));	/* T5: key not found */
+    if (q != (struct node_t *)0) {	/* make new node */
+	*rootp = q;			/* link new node to old */
+	q->key = key;			/* initialize new node */
+	q->left = q->right = (struct node_t *)0;
+    }
+    return ((void *)q);
+}
+
+/* delete node with given key */
+void *
+tdelete(const void *vkey, void **vrootp,
+    int (*compar)(const void *, const void *))
+{
+    node **rootp = (node **)vrootp;
+    char *key = (char *)vkey;
+    node *p = (node *)1;
+    node *q;
+    node *r;
+    int cmp;
+
+    if (rootp == (struct node_t **)0 || *rootp == (struct node_t *)0)
+	return ((struct node_t *)0);
+    while ((cmp = (*compar)(key, (*rootp)->key)) != 0) {
+	p = *rootp;
+	rootp = (cmp < 0) ?
+	    &(*rootp)->left :		/* follow left branch */
+	    &(*rootp)->right;		/* follow right branch */
+	if (*rootp == (struct node_t *)0)
+	    return ((void *)0);		/* key not found */
+    }
+    r = (*rootp)->right;			/* D1: */
+    if ((q = (*rootp)->left) == (struct node_t *)0)	/* Left (struct node_t *)0? */
+	q = r;
+    else if (r != (struct node_t *)0) {		/* Right link is null? */
+	if (r->left == (struct node_t *)0) {	/* D2: Find successor */
+	    r->left = q;
+	    q = r;
+	} else {			/* D3: Find (struct node_t *)0 link */
+	    for (q = r->left; q->left != (struct node_t *)0; q = r->left)
+		r = q;
+	    r->left = q->right;
+	    q->left = (*rootp)->left;
+	    q->right = (*rootp)->right;
+	}
+    }
+    free((struct node_t *) *rootp);	/* D4: Free node */
+    *rootp = q;				/* link parent to new node */
+    return(p);
+}
+
+/* Walk the nodes of a tree */
+static void
+trecurse(node *root, void (*action)(const void *, VISIT, int), int level)
+{
+    if (root->left == (struct node_t *)0 && root->right == (struct node_t *)0)
+	(*action)(root, leaf, level);
+    else {
+	(*action)(root, preorder, level);
+	if (root->left != (struct node_t *)0)
+	    trecurse(root->left, action, level + 1);
+	(*action)(root, postorder, level);
+	if (root->right != (struct node_t *)0)
+	    trecurse(root->right, action, level + 1);
+	(*action)(root, endorder, level);
+    }
+}
+
+/* Walk the nodes of a tree */
+void
+twalk(const void *vroot, void (*action)(const void *, VISIT, int))
+{
+    node *root = (node *)vroot;
+
+    if (root != (node *)0 && action != (void (*)(const void *, VISIT, int))0)
+	trecurse(root, action, 0);
+}
+
+/*	$OpenBSD: tfind.c,v 1.6 2014/03/16 18:38:30 guenther Exp $	*/
+
+/* find a node, or return 0 */
+void *
+tfind(const void *vkey, void * const *vrootp,
+    int (*compar)(const void *, const void *))
+{
+    char *key = (char *)vkey;
+    node **rootp = (node **)vrootp;
+
+    if (rootp == (struct node_t **)0)
+	return ((struct node_t *)0);
+    while (*rootp != (struct node_t *)0) {	/* T1: */
+	int r;
+	if ((r = (*compar)(key, (*rootp)->key)) == 0)	/* T2: */
+	    return (*rootp);		/* key found */
+	rootp = (r < 0) ?
+	    &(*rootp)->left :		/* T3: follow left branch */
+	    &(*rootp)->right;		/* T4: follow right branch */
+    }
+    return (node *)0;
+}

--- a/src/tsearch.h
+++ b/src/tsearch.h
@@ -1,0 +1,26 @@
+#ifndef HAMMER_TSEARCH__H
+#define HAMMER_TSEARCH__H
+
+#if defined(_MSC_VER)
+typedef enum { preorder, postorder, endorder, leaf } VISIT;
+
+/* find or insert datum into search tree */
+void *tsearch(const void *vkey, void **vrootp,
+              int (*compar)(const void *, const void *));
+
+/* delete node with given key */
+void * tdelete(const void *vkey, void **vrootp,
+               int (*compar)(const void *, const void *));
+
+/* Walk the nodes of a tree */
+void twalk(const void *vroot, void (*action)(const void *, VISIT, int));
+
+/* find a node, or return 0 */
+void *tfind(const void *vkey, void * const *vrootp,
+            int (*compar)(const void *, const void *));
+
+#else
+#include <search.h>
+#endif
+
+#endif /* HAMMER_TSEARCH__H */

--- a/tools/windows/clvars.bat
+++ b/tools/windows/clvars.bat
@@ -10,12 +10,12 @@ set WARNINGS=%WARNINGS% -wd4464
 REM c4189 (local variable is initialized but not referenced)
 set WARNINGS=%WARNINGS% -wd4189
 
-REM c4018 (signed/unsigned mismatch)
+REM c4018/c4388 (signed/unsigned mismatch)
 REM basically useless. Complains about obviously correct code like:
 REM     uint8_t x = 60;
 REM     size_t i = 9;
 REM     i < x/8
-set WARNINGS=%WARNINGS% -wd4018
+set WARNINGS=%WARNINGS% -wd4018 -wd4388
 
 REM c4457 (declaration shadowing function parameter)
 REM FIXME(windows) TODO(uucidl): remove occurence of c4457 and reactivate

--- a/tools/windows/clvars.bat
+++ b/tools/windows/clvars.bat
@@ -7,6 +7,16 @@ set WARNINGS=-W4 -Wall -WX
 REM c4464 (relative include path contains '..')
 set WARNINGS=%WARNINGS% -wd4464
 
+REM c4189 (local variable is initialized but not referenced)
+set WARNINGS=%WARNINGS% -wd4189
+
+REM c4018 (signed/unsigned mismatch)
+REM basically useless. Complains about obviously correct code like:
+REM     uint8_t x = 60;
+REM     size_t i = 9;
+REM     i < x/8
+set WARNINGS=%WARNINGS% -wd4018
+
 REM c4457 (declaration shadowing function parameter)
 REM FIXME(windows) TODO(uucidl): remove occurence of c4457 and reactivate
 REM FIXME(windows) TODO(uucidl): remove occurence of c4456 and reactivate

--- a/tools/windows/hammer_lib_src_list
+++ b/tools/windows/hammer_lib_src_list
@@ -3,7 +3,8 @@ allocator.c
 benchmark.c
 bitreader.c 
 bitwriter.c 
-cfgrammar.c 
+cfgrammar.c
+datastructures.c
 desugar.c 
 glue.c 
 hammer.c 

--- a/tools/windows/hammer_lib_src_list
+++ b/tools/windows/hammer_lib_src_list
@@ -9,7 +9,9 @@ desugar.c
 glue.c 
 hammer.c 
 pprint.c
+registry.c
 system_allocator.c
+tsearch.c
 parsers/action.c 
 parsers/and.c 
 parsers/attr_bool.c 

--- a/tools/windows/hammer_lib_src_list
+++ b/tools/windows/hammer_lib_src_list
@@ -12,9 +12,12 @@ system_allocator.c
 parsers/action.c 
 parsers/and.c 
 parsers/attr_bool.c 
+parsers/bind.c
+parsers/bits.c
 parsers/butnot.c 
 parsers/ch.c 
 parsers/charset.c 
+parsers/choice.c
 parsers/difference.c 
 parsers/end.c 
 parsers/endianness.c 
@@ -25,6 +28,7 @@ parsers/indirect.c
 parsers/int_range.c 
 parsers/many.c 
 parsers/not.c 
+parsers/nothing.c
 parsers/optional.c 
 parsers/permutation.c 	
 parsers/sequence.c 


### PR DESCRIPTION
This pull request is mainly deactivating or fixing warnings that MSVC would emit on the parser code.

The only significant change is to choice's regex constructor implementation, where the _gotos_ array used to be allocated on the stack as a variable-length array. It is now heap allocated and freed before returning.

Let me know if anything needs to be changed.

In my next effort I will port the registry.c file which is the only remaining part of the library which is currently not building on windows (because it uses a unix only tree library)