### PR TITLE
fixed include for internal.h

### DIFF
--- a/src/test_suite.h
+++ b/src/test_suite.h
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 #include <inttypes.h>
 
-#include "internal.h"
+#include <hammer/internal.h>
 
 // Equivalent to g_assert_*, but not using g_assert...
 #define g_check_inttype(fmt, typ, n1, op, n2) do {				\


### PR DESCRIPTION
Hi there,

i adjusted the inclusion of "internal.h" to (re-)enable workflow described in lecture 10 of the [Hammer Primer](https://github.com/sergeybratus/HammerPrimer). The old yielded:

```
 gcc -o test_base64 base64.c -lhammer `pkg-config --libs glib-2.0`
 In file included from test_suite.h:24:0,
                  from base64.c:2:
 internal.h:28:20: fatal error: hammer.h: file or directory not found
  #include "hammer.h"
```
This PR fixes this.

Cheers,
tomime