### PR TITLE
add const to the pointer arg to h_make_bytes

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -106,7 +106,7 @@ HParsedToken *h_make_seqn(HArena *arena, size_t n)
   return ret;
 }
 
-HParsedToken *h_make_bytes(HArena *arena, uint8_t *array, size_t len)
+HParsedToken *h_make_bytes(HArena *arena, const uint8_t *array, size_t len)
 {
   HParsedToken *ret = h_make_(arena, TT_BYTES);
   ret->bytes.len = len;

--- a/src/glue.h
+++ b/src/glue.h
@@ -195,7 +195,7 @@ HParsedToken *h_act_ignore(const HParseResult *p, void* user_data);
 HParsedToken *h_make(HArena *arena, HTokenType type, void *value);
 HParsedToken *h_make_seq(HArena *arena);  // Makes empty sequence.
 HParsedToken *h_make_seqn(HArena *arena, size_t n);  // Makes empty sequence of expected size n.
-HParsedToken *h_make_bytes(HArena *arena, uint8_t *array, size_t len);
+HParsedToken *h_make_bytes(HArena *arena, const uint8_t *array, size_t len);
 HParsedToken *h_make_sint(HArena *arena, int64_t val);
 HParsedToken *h_make_uint(HArena *arena, uint64_t val);
 


### PR DESCRIPTION
got a compiler complaint in my PDF parser from this: can't use `h_make_bytes()` on arrays you only have a const handle on.

i think this was probably a simple oversight in the type (the field in HBytes is const anyway), but my mind is elsewhere right now, so I'm leaving it as an open pull request for the moment.